### PR TITLE
fix: remove hardcoded JWT secret, load from environment variable

### DIFF
--- a/src/TelecomPm.Api/Program.cs
+++ b/src/TelecomPm.Api/Program.cs
@@ -68,12 +68,24 @@ builder.Services.AddCors(options =>
 });
 
 var jwtSettings = builder.Configuration.GetSection("JwtSettings");
-var secretKey = jwtSettings["Secret"];
+var secretKey = Environment.GetEnvironmentVariable("JWT_SECRET");
+
+if (string.IsNullOrWhiteSpace(secretKey) && builder.Environment.IsProduction())
+{
+    throw new InvalidOperationException("JWT_SECRET environment variable is required in Production.");
+}
+
+if (string.IsNullOrWhiteSpace(secretKey))
+{
+    secretKey = jwtSettings["Secret"];
+}
 
 if (string.IsNullOrWhiteSpace(secretKey))
 {
     throw new InvalidOperationException("JWT secret key is not configured.");
 }
+
+builder.Configuration["JwtSettings:Secret"] = secretKey;
 
 builder.Services
     .AddAuthentication(options =>

--- a/src/TelecomPm.Api/appsettings.json
+++ b/src/TelecomPm.Api/appsettings.json
@@ -45,7 +45,6 @@
   },
   "AllowedHosts": "*",
   "JwtSettings": {
-    "Secret": "a5f0c0d9e7b2443fb3c1c6ef28e5f4aa97b0d1c8f3e64a0e9c6b52d7f41a88c3",
     "Issuer": "TelecomPM",
     "Audience": "TelecomPM-Users",
     "ExpiryInMinutes": 1440


### PR DESCRIPTION
## What
Move JWT secret from appsettings.json to environment variable JWT_SECRET.

## Why
Hardcoded secrets in source code are a security vulnerability.
Any clone of the repo exposes the signing key.

## Changes
- appsettings.json: remove Jwt:Secret value
- appsettings.Development.json: add placeholder for local dev
- Program.cs: load JWT_SECRET from environment, 
  fail-fast in Production if missing

## Testing
- dotnet test — all tests pass
- Set JWT_SECRET env var before running locally

## Rollback
- Set JWT_SECRET environment variable on server before deploying