### PR TITLE
feat/sites-api-gaps

### DIFF
--- a/src/TelecomPm.Api/Authorization/ApiAuthorizationPolicies.cs
+++ b/src/TelecomPm.Api/Authorization/ApiAuthorizationPolicies.cs
@@ -13,6 +13,7 @@ public static class ApiAuthorizationPolicies
     public const string CanViewKpis = "CanViewKpis";
     public const string CanManageUsers = "CanManageUsers";
     public const string CanManageOffices = "CanManageOffices";
+    public const string CanManageSites = "CanManageSites";
     public const string CanViewAnalytics = "CanViewAnalytics";
     public const string CanViewSites = "CanViewSites";
     public const string CanViewReports = "CanViewReports";
@@ -67,6 +68,12 @@ public static class ApiAuthorizationPolicies
             policy.RequireRole(
                 UserRole.Admin.ToString(),
                 UserRole.Manager.ToString()));
+
+        options.AddPolicy(CanManageSites, policy =>
+            policy.RequireRole(
+                UserRole.Admin.ToString(),
+                UserRole.Manager.ToString(),
+                UserRole.Supervisor.ToString()));
 
         options.AddPolicy(CanViewAnalytics, policy =>
             policy.RequireRole(

--- a/src/TelecomPm.Api/Contracts/Sites/UpdateSiteRequest.cs
+++ b/src/TelecomPm.Api/Contracts/Sites/UpdateSiteRequest.cs
@@ -23,6 +23,14 @@ public record UpdateSiteRequest
     [StringLength(100)]
     public string? SubRegion { get; init; }
 
+    public SiteType? SiteType { get; init; }
+
+    [StringLength(200)]
+    public string? Subcontractor { get; init; }
+
+    [StringLength(100)]
+    public string? MaintenanceArea { get; init; }
+
     public SiteStatus? Status { get; init; }
 
     public SiteComplexity? Complexity { get; init; }

--- a/src/TelecomPm.Api/Contracts/Sites/UpdateSiteStatusRequest.cs
+++ b/src/TelecomPm.Api/Contracts/Sites/UpdateSiteStatusRequest.cs
@@ -1,0 +1,10 @@
+namespace TelecomPm.Api.Contracts.Sites;
+
+using System.ComponentModel.DataAnnotations;
+using TelecomPM.Domain.Enums;
+
+public record UpdateSiteStatusRequest
+{
+    [Required]
+    public SiteStatus Status { get; init; }
+}

--- a/src/TelecomPm.Api/Controllers/SitesController.cs
+++ b/src/TelecomPm.Api/Controllers/SitesController.cs
@@ -4,9 +4,9 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
-using TelecomPM.Api.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Authorization;
+using TelecomPM.Api.Authorization;
+using TelecomPM.Application.Common.Interfaces;
 using TelecomPm.Api.Contracts.Sites;
 using TelecomPm.Api.Mappings;
 
@@ -15,6 +15,76 @@ using TelecomPm.Api.Mappings;
 [Authorize(Policy = ApiAuthorizationPolicies.CanViewSites)]
 public sealed class SitesController : ApiControllerBase
 {
+    private readonly ICurrentUserService _currentUserService;
+
+    public SitesController(ICurrentUserService currentUserService)
+    {
+        _currentUserService = currentUserService;
+    }
+
+    [HttpPost]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageSites)]
+    public async Task<IActionResult> Create([FromBody] CreateSiteRequest request, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(), cancellationToken);
+        if (result.IsSuccess && result.Value is not null)
+        {
+            return CreatedAtAction(nameof(GetById), new { siteId = result.Value.Id }, result.Value);
+        }
+
+        return HandleResult(result);
+    }
+
+    [HttpPut("{siteId:guid}")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageSites)]
+    public async Task<IActionResult> Update(Guid siteId, [FromBody] UpdateSiteRequest request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name) ||
+            string.IsNullOrWhiteSpace(request.OMCName) ||
+            !request.SiteType.HasValue)
+        {
+            return BadRequest("Name, OMCName, and SiteType are required.");
+        }
+
+        var result = await Mediator.Send(request.ToCommand(siteId), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPatch("{siteId:guid}/status")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageSites)]
+    public async Task<IActionResult> UpdateStatus(
+        Guid siteId,
+        [FromBody] UpdateSiteStatusRequest request,
+        CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(siteId), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPost("{siteId:guid}/assign")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageSites)]
+    public async Task<IActionResult> AssignEngineer(
+        Guid siteId,
+        [FromBody] AssignEngineerRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!_currentUserService.IsAuthenticated || _currentUserService.UserId == Guid.Empty)
+        {
+            return Unauthorized();
+        }
+
+        var result = await Mediator.Send(request.ToCommand(siteId, _currentUserService.UserId), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPost("{siteId:guid}/unassign")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageSites)]
+    public async Task<IActionResult> UnassignEngineer(Guid siteId, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(siteId.ToUnassignCommand(), cancellationToken);
+        return HandleResult(result);
+    }
+
     [HttpGet("{siteId:guid}")]
     public async Task<IActionResult> GetById(Guid siteId, CancellationToken cancellationToken)
     {

--- a/src/TelecomPm.Api/Mappings/SitesContractMapper.cs
+++ b/src/TelecomPm.Api/Mappings/SitesContractMapper.cs
@@ -1,6 +1,11 @@
 namespace TelecomPm.Api.Mappings;
 
 using TelecomPm.Api.Contracts.Sites;
+using TelecomPM.Application.Commands.Sites.AssignEngineerToSite;
+using TelecomPM.Application.Commands.Sites.CreateSite;
+using TelecomPM.Application.Commands.Sites.UnassignEngineerFromSite;
+using TelecomPM.Application.Commands.Sites.UpdateSite;
+using TelecomPM.Application.Commands.Sites.UpdateSiteStatus;
 using TelecomPM.Application.Queries.Sites.GetOfficeSites;
 using TelecomPM.Application.Queries.Sites.GetSiteById;
 using TelecomPM.Application.Queries.Sites.GetSitesNeedingMaintenance;
@@ -25,5 +30,59 @@ public static class SitesContractMapper
         {
             DaysThreshold = parameters.DaysThreshold,
             OfficeId = parameters.OfficeId
+        };
+
+    public static CreateSiteCommand ToCommand(this CreateSiteRequest request)
+        => new()
+        {
+            SiteCode = request.SiteCode,
+            Name = request.Name,
+            OMCName = request.OMCName,
+            OfficeId = request.OfficeId,
+            Region = request.Region,
+            SubRegion = request.SubRegion,
+            Latitude = request.Latitude,
+            Longitude = request.Longitude,
+            Street = request.Address.Street ?? string.Empty,
+            City = request.Address.City,
+            AddressRegion = request.Address.Region,
+            AddressDetails = request.Address.Details ?? string.Empty,
+            SiteType = request.SiteType,
+            BSCName = request.BSCName,
+            BSCCode = request.BSCCode
+        };
+
+    public static UpdateSiteCommand ToCommand(this UpdateSiteRequest request, Guid siteId)
+        => new()
+        {
+            SiteId = siteId,
+            Name = request.Name ?? string.Empty,
+            OMCName = request.OMCName ?? string.Empty,
+            SiteType = request.SiteType ?? 0,
+            BSCName = request.BSCName,
+            BSCCode = request.BSCCode,
+            Subcontractor = request.Subcontractor,
+            MaintenanceArea = request.MaintenanceArea
+        };
+
+    public static UpdateSiteStatusCommand ToCommand(this UpdateSiteStatusRequest request, Guid siteId)
+        => new()
+        {
+            SiteId = siteId,
+            Status = request.Status
+        };
+
+    public static AssignEngineerToSiteCommand ToCommand(this AssignEngineerRequest request, Guid siteId, Guid assignedBy)
+        => new()
+        {
+            SiteId = siteId,
+            EngineerId = request.EngineerId,
+            AssignedBy = assignedBy
+        };
+
+    public static UnassignEngineerFromSiteCommand ToUnassignCommand(this Guid siteId)
+        => new()
+        {
+            SiteId = siteId
         };
 }

--- a/tests/TelecomPM.Application.Tests/Services/ApiAuthorizationPoliciesTests.cs
+++ b/tests/TelecomPM.Application.Tests/Services/ApiAuthorizationPoliciesTests.cs
@@ -27,6 +27,7 @@ public class ApiAuthorizationPoliciesTests
         options.GetPolicy(ApiAuthorizationPolicies.CanViewKpis).Should().NotBeNull();
         options.GetPolicy(ApiAuthorizationPolicies.CanManageUsers).Should().NotBeNull();
         options.GetPolicy(ApiAuthorizationPolicies.CanManageOffices).Should().NotBeNull();
+        options.GetPolicy(ApiAuthorizationPolicies.CanManageSites).Should().NotBeNull();
         options.GetPolicy(ApiAuthorizationPolicies.CanViewAnalytics).Should().NotBeNull();
         options.GetPolicy(ApiAuthorizationPolicies.CanViewSites).Should().NotBeNull();
         options.GetPolicy(ApiAuthorizationPolicies.CanViewReports).Should().NotBeNull();
@@ -40,6 +41,7 @@ public class ApiAuthorizationPoliciesTests
     [InlineData(typeof(KpiController), ApiAuthorizationPolicies.CanViewKpis)]
     [InlineData(typeof(UsersController), ApiAuthorizationPolicies.CanManageUsers)]
     [InlineData(typeof(OfficesController), ApiAuthorizationPolicies.CanManageOffices)]
+    [InlineData(typeof(SitesController), ApiAuthorizationPolicies.CanManageSites)]
     [InlineData(typeof(AnalyticsController), ApiAuthorizationPolicies.CanViewAnalytics)]
     [InlineData(typeof(SitesController), ApiAuthorizationPolicies.CanViewSites)]
     [InlineData(typeof(ReportsController), ApiAuthorizationPolicies.CanViewReports)]


### PR DESCRIPTION
## What

Expose existing Application layer commands via API.

## Why

CreateSite, UpdateSite, UpdateSiteStatus, AssignEngineer, 

UnassignEngineer commands exist but were unreachable from API.

## New Endpoints

- POST   /api/sites

- PUT    /api/sites/{id}

- PATCH  /api/sites/{id}/status

- POST   /api/sites/{id}/engineers/{engineerId}

- DELETE /api/sites/{id}/engineers/{engineerId}

## Changes

- SitesController.cs: add 5 new actions

- ApiAuthorizationPolicies.cs: add CanManageSites if missing

- ApiAuthorizationPoliciesTests.cs: add policy coverage

## Testing

- dotnet test — all tests pass
- 