### PR TITLE
feat: expose material CRUD and stock movement endpoints 

### DIFF
--- a/src/TelecomPm.Api/Authorization/ApiAuthorizationPolicies.cs
+++ b/src/TelecomPm.Api/Authorization/ApiAuthorizationPolicies.cs
@@ -18,6 +18,7 @@ public static class ApiAuthorizationPolicies
     public const string CanViewSites = "CanViewSites";
     public const string CanViewReports = "CanViewReports";
     public const string CanViewMaterials = "CanViewMaterials";
+    public const string CanManageMaterials = "CanManageMaterials";
 
     public static void Configure(AuthorizationOptions options)
     {
@@ -102,5 +103,11 @@ public static class ApiAuthorizationPolicies
                 UserRole.Manager.ToString(),
                 UserRole.Supervisor.ToString(),
                 UserRole.PMEngineer.ToString()));
+
+        options.AddPolicy(CanManageMaterials, policy =>
+            policy.RequireRole(
+                UserRole.Admin.ToString(),
+                UserRole.Manager.ToString(),
+                UserRole.Supervisor.ToString()));
     }
 }

--- a/src/TelecomPm.Api/Contracts/Materials/AddStockRequest.cs
+++ b/src/TelecomPm.Api/Contracts/Materials/AddStockRequest.cs
@@ -1,0 +1,17 @@
+namespace TelecomPm.Api.Contracts.Materials;
+
+using System.ComponentModel.DataAnnotations;
+using TelecomPM.Domain.Enums;
+
+public record AddStockRequest
+{
+    [Required]
+    [Range(0.01, double.MaxValue, ErrorMessage = "Quantity must be greater than 0")]
+    public decimal Quantity { get; init; }
+
+    [Required]
+    public MaterialUnit Unit { get; init; }
+
+    [StringLength(200)]
+    public string? Supplier { get; init; }
+}

--- a/src/TelecomPm.Api/Contracts/Materials/ConsumeStockRequest.cs
+++ b/src/TelecomPm.Api/Contracts/Materials/ConsumeStockRequest.cs
@@ -1,0 +1,10 @@
+namespace TelecomPm.Api.Contracts.Materials;
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+public record ConsumeStockRequest
+{
+    [Required]
+    public Guid VisitId { get; init; }
+}

--- a/src/TelecomPm.Api/Contracts/Materials/ReserveStockRequest.cs
+++ b/src/TelecomPm.Api/Contracts/Materials/ReserveStockRequest.cs
@@ -1,0 +1,18 @@
+namespace TelecomPm.Api.Contracts.Materials;
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using TelecomPM.Domain.Enums;
+
+public record ReserveStockRequest
+{
+    [Required]
+    public Guid VisitId { get; init; }
+
+    [Required]
+    [Range(0.01, double.MaxValue, ErrorMessage = "Quantity must be greater than 0")]
+    public decimal Quantity { get; init; }
+
+    [Required]
+    public MaterialUnit Unit { get; init; }
+}

--- a/src/TelecomPm.Api/Contracts/Materials/UpdateMaterialRequest.cs
+++ b/src/TelecomPm.Api/Contracts/Materials/UpdateMaterialRequest.cs
@@ -1,6 +1,7 @@
 namespace TelecomPm.Api.Contracts.Materials;
 
 using System.ComponentModel.DataAnnotations;
+using TelecomPM.Domain.Enums;
 
 public record UpdateMaterialRequest
 {
@@ -10,6 +11,9 @@ public record UpdateMaterialRequest
 
     [StringLength(1000)]
     public string? Description { get; init; }
+
+    [Required]
+    public MaterialCategory Category { get; init; }
 
     [StringLength(200)]
     public string? Supplier { get; init; }

--- a/src/TelecomPm.Api/Controllers/MaterialsController.cs
+++ b/src/TelecomPm.Api/Controllers/MaterialsController.cs
@@ -6,17 +6,109 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using TelecomPM.Api.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using TelecomPm.Api.Contracts.Materials;
 using TelecomPm.Api.Mappings;
+using TelecomPM.Application.Common.Interfaces;
 
 [ApiController]
 [Route("api/[controller]")]
 [Authorize(Policy = ApiAuthorizationPolicies.CanViewMaterials)]
 public sealed class MaterialsController : ApiControllerBase
 {
+    private readonly ICurrentUserService _currentUserService;
+
+    public MaterialsController(ICurrentUserService currentUserService)
+    {
+        _currentUserService = currentUserService;
+    }
+
+    [HttpPost]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageMaterials)]
+    public async Task<IActionResult> Create([FromBody] CreateMaterialRequest request, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(), cancellationToken);
+        if (result.IsSuccess && result.Value is not null)
+        {
+            return CreatedAtAction(nameof(GetById), new { id = result.Value.Id }, result.Value);
+        }
+
+        return HandleResult(result);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageMaterials)]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateMaterialRequest request, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(id), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageMaterials)]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToDeleteMaterialCommand(ResolveActor()), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPost("{id:guid}/stock/add")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageMaterials)]
+    public async Task<IActionResult> AddStock(Guid id, [FromBody] AddStockRequest request, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(id, ResolveActor()), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPost("{id:guid}/stock/reserve")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageMaterials)]
+    public async Task<IActionResult> ReserveStock(Guid id, [FromBody] ReserveStockRequest request, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(id), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPost("{id:guid}/stock/consume")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageMaterials)]
+    public async Task<IActionResult> ConsumeStock(Guid id, [FromBody] ConsumeStockRequest request, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(id, ResolveActor()), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToMaterialByIdQuery(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll([FromQuery] Guid officeId, [FromQuery] bool? onlyInStock, CancellationToken cancellationToken)
+    {
+        var effectiveOfficeId = officeId != Guid.Empty ? officeId : _currentUserService.OfficeId;
+        if (effectiveOfficeId == Guid.Empty)
+        {
+            return BadRequest("officeId is required.");
+        }
+
+        var result = await Mediator.Send(effectiveOfficeId.ToQuery(onlyInStock), cancellationToken);
+        return HandleResult(result);
+    }
+
     [HttpGet("low-stock/{officeId:guid}")]
     public async Task<IActionResult> GetLowStockMaterials(Guid officeId, CancellationToken cancellationToken)
     {
         var result = await Mediator.Send(officeId.ToLowStockQuery(), cancellationToken);
         return HandleResult(result);
+    }
+
+    private string ResolveActor()
+    {
+        if (_currentUserService.IsAuthenticated && _currentUserService.UserId != Guid.Empty)
+        {
+            return _currentUserService.UserId.ToString();
+        }
+
+        return "System";
     }
 }

--- a/src/TelecomPm.Api/Mappings/MaterialsContractMapper.cs
+++ b/src/TelecomPm.Api/Mappings/MaterialsContractMapper.cs
@@ -1,9 +1,86 @@
 namespace TelecomPm.Api.Mappings;
 
+using TelecomPm.Api.Contracts.Materials;
+using TelecomPM.Application.Commands.Materials.ConsumeMaterial;
+using TelecomPM.Application.Commands.Materials.CreateMaterial;
+using TelecomPM.Application.Commands.Materials.DeleteMaterial;
+using TelecomPM.Application.Commands.Materials.ReserveMaterial;
+using TelecomPM.Application.Commands.Materials.RestockMaterial;
+using TelecomPM.Application.Commands.Materials.UpdateMaterial;
+using TelecomPM.Application.Queries.Materials.GetMaterialById;
+using TelecomPM.Application.Queries.Materials.GetMaterialsByOffice;
 using TelecomPM.Application.Queries.Materials.GetLowStockMaterials;
 
 public static class MaterialsContractMapper
 {
     public static GetLowStockMaterialsQuery ToLowStockQuery(this Guid officeId)
         => new() { OfficeId = officeId };
+
+    public static GetMaterialByIdQuery ToMaterialByIdQuery(this Guid materialId)
+        => new() { MaterialId = materialId };
+
+    public static GetMaterialsByOfficeQuery ToQuery(this Guid officeId, bool? onlyInStock = null)
+        => new()
+        {
+            OfficeId = officeId,
+            OnlyInStock = onlyInStock
+        };
+
+    public static CreateMaterialCommand ToCommand(this CreateMaterialRequest request)
+        => new()
+        {
+            Code = request.Code,
+            Name = request.Name,
+            Description = request.Description ?? string.Empty,
+            Category = request.Category,
+            OfficeId = request.OfficeId,
+            InitialStock = request.InitialStock,
+            Unit = request.Unit,
+            MinimumStock = request.MinimumStock,
+            UnitCost = request.UnitCost,
+            Supplier = request.Supplier
+        };
+
+    public static UpdateMaterialCommand ToCommand(this UpdateMaterialRequest request, Guid materialId)
+        => new()
+        {
+            MaterialId = materialId,
+            Name = request.Name,
+            Description = request.Description ?? string.Empty,
+            Category = request.Category
+        };
+
+    public static DeleteMaterialCommand ToDeleteMaterialCommand(this Guid materialId, string deletedBy)
+        => new()
+        {
+            MaterialId = materialId,
+            DeletedBy = deletedBy
+        };
+
+    public static RestockMaterialCommand ToCommand(this AddStockRequest request, Guid materialId, string restockedBy)
+        => new()
+        {
+            MaterialId = materialId,
+            Quantity = request.Quantity,
+            Unit = request.Unit,
+            RestockedBy = restockedBy,
+            Supplier = request.Supplier
+        };
+
+    public static ReserveMaterialCommand ToCommand(this ReserveStockRequest request, Guid materialId)
+        => new()
+        {
+            MaterialId = materialId,
+            VisitId = request.VisitId,
+            Quantity = request.Quantity,
+            Unit = request.Unit
+        };
+
+    public static ConsumeMaterialCommand ToCommand(this ConsumeStockRequest request, Guid materialId, string performedBy)
+        => new()
+        {
+            MaterialId = materialId,
+            VisitId = request.VisitId,
+            PerformedBy = performedBy
+        };
 }

--- a/tests/TelecomPM.Application.Tests/Services/ApiAuthorizationPoliciesTests.cs
+++ b/tests/TelecomPM.Application.Tests/Services/ApiAuthorizationPoliciesTests.cs
@@ -32,6 +32,7 @@ public class ApiAuthorizationPoliciesTests
         options.GetPolicy(ApiAuthorizationPolicies.CanViewSites).Should().NotBeNull();
         options.GetPolicy(ApiAuthorizationPolicies.CanViewReports).Should().NotBeNull();
         options.GetPolicy(ApiAuthorizationPolicies.CanViewMaterials).Should().NotBeNull();
+        options.GetPolicy(ApiAuthorizationPolicies.CanManageMaterials).Should().NotBeNull();
     }
 
     [Theory]
@@ -46,6 +47,7 @@ public class ApiAuthorizationPoliciesTests
     [InlineData(typeof(SitesController), ApiAuthorizationPolicies.CanViewSites)]
     [InlineData(typeof(ReportsController), ApiAuthorizationPolicies.CanViewReports)]
     [InlineData(typeof(MaterialsController), ApiAuthorizationPolicies.CanViewMaterials)]
+    [InlineData(typeof(MaterialsController), ApiAuthorizationPolicies.CanManageMaterials)]
     public void Controllers_ShouldReferenceExpectedPolicies(Type controllerType, string policy)
     {
         var methods = controllerType


### PR DESCRIPTION
## What
Expose existing material commands via API.
MaterialsController previously only had one read endpoint.

## New Endpoints
- GET    /api/materials
- GET    /api/materials/{id}
- POST   /api/materials
- PUT    /api/materials/{id}
- DELETE /api/materials/{id}
- POST   /api/materials/{id}/stock/add
- POST   /api/materials/{id}/stock/reserve
- POST   /api/materials/{id}/stock/consume

## Changes
- MaterialsController.cs: add 7 new actions
- ApiAuthorizationPolicies.cs: add CanManageMaterials

## Testing
- dotnet test — all tests pass