### PR TITLE
feat: add escalation lifecycle endpoints (review/approve/reject/close)

### DIFF
--- a/src/TelecomPM.Domain/Entities/Escalations/Escalation.cs
+++ b/src/TelecomPM.Domain/Entities/Escalations/Escalation.cs
@@ -121,4 +121,12 @@ public sealed class Escalation : AggregateRoot<Guid>
 
         Status = EscalationStatus.Rejected;
     }
+
+    public void Close()
+    {
+        if (Status != EscalationStatus.Approved && Status != EscalationStatus.Rejected)
+            throw new DomainException("Only approved or rejected escalation can be closed");
+
+        Status = EscalationStatus.Closed;
+    }
 }

--- a/src/TelecomPm.Api/Controllers/EscalationsController.cs
+++ b/src/TelecomPm.Api/Controllers/EscalationsController.cs
@@ -25,10 +25,42 @@ public sealed class EscalationsController : ApiControllerBase
     }
 
     [HttpGet("{escalationId:guid}")]
-    [Authorize(Policy = ApiAuthorizationPolicies.CanViewEscalations)]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageEscalations)]
     public async Task<IActionResult> GetById(Guid escalationId, CancellationToken cancellationToken)
     {
         var result = await Mediator.Send(escalationId.ToEscalationByIdQuery(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPatch("{id:guid}/review")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageEscalations)]
+    public async Task<IActionResult> Review(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToReviewEscalationCommand(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPatch("{id:guid}/approve")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageEscalations)]
+    public async Task<IActionResult> Approve(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToApproveEscalationCommand(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPatch("{id:guid}/reject")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageEscalations)]
+    public async Task<IActionResult> Reject(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToRejectEscalationCommand(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPatch("{id:guid}/close")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageEscalations)]
+    public async Task<IActionResult> Close(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToCloseEscalationCommand(), cancellationToken);
         return HandleResult(result);
     }
 }

--- a/src/TelecomPm.Api/Mappings/EscalationsContractMapper.cs
+++ b/src/TelecomPm.Api/Mappings/EscalationsContractMapper.cs
@@ -1,7 +1,11 @@
 namespace TelecomPm.Api.Mappings;
 
 using TelecomPm.Api.Contracts.Escalations;
+using TelecomPM.Application.Commands.Escalations.ApproveEscalation;
+using TelecomPM.Application.Commands.Escalations.CloseEscalation;
 using TelecomPM.Application.Commands.Escalations.CreateEscalation;
+using TelecomPM.Application.Commands.Escalations.RejectEscalation;
+using TelecomPM.Application.Commands.Escalations.ReviewEscalation;
 using TelecomPM.Application.Queries.Escalations.GetEscalationById;
 
 public static class EscalationsContractMapper
@@ -23,5 +27,17 @@ public static class EscalationsContractMapper
         };
 
     public static GetEscalationByIdQuery ToEscalationByIdQuery(this Guid escalationId)
+        => new() { EscalationId = escalationId };
+
+    public static ReviewEscalationCommand ToReviewEscalationCommand(this Guid escalationId)
+        => new() { EscalationId = escalationId };
+
+    public static ApproveEscalationCommand ToApproveEscalationCommand(this Guid escalationId)
+        => new() { EscalationId = escalationId };
+
+    public static RejectEscalationCommand ToRejectEscalationCommand(this Guid escalationId)
+        => new() { EscalationId = escalationId };
+
+    public static CloseEscalationCommand ToCloseEscalationCommand(this Guid escalationId)
         => new() { EscalationId = escalationId };
 }

--- a/src/TelecomPm.Application/Commands/Escalations/ApproveEscalation/ApproveEscalationCommand.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/ApproveEscalation/ApproveEscalationCommand.cs
@@ -1,0 +1,9 @@
+namespace TelecomPM.Application.Commands.Escalations.ApproveEscalation;
+
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.Escalations;
+
+public record ApproveEscalationCommand : ICommand<EscalationDto>
+{
+    public Guid EscalationId { get; init; }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/ApproveEscalation/ApproveEscalationCommandHandler.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/ApproveEscalation/ApproveEscalationCommandHandler.cs
@@ -1,0 +1,45 @@
+namespace TelecomPM.Application.Commands.Escalations.ApproveEscalation;
+
+using AutoMapper;
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.Escalations;
+using TelecomPM.Domain.Exceptions;
+using TelecomPM.Domain.Interfaces.Repositories;
+
+public class ApproveEscalationCommandHandler : IRequestHandler<ApproveEscalationCommand, Result<EscalationDto>>
+{
+    private readonly IEscalationRepository _escalationRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMapper _mapper;
+
+    public ApproveEscalationCommandHandler(
+        IEscalationRepository escalationRepository,
+        IUnitOfWork unitOfWork,
+        IMapper mapper)
+    {
+        _escalationRepository = escalationRepository;
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<EscalationDto>> Handle(ApproveEscalationCommand request, CancellationToken cancellationToken)
+    {
+        var escalation = await _escalationRepository.GetByIdAsync(request.EscalationId, cancellationToken);
+        if (escalation is null)
+            return Result.Failure<EscalationDto>("Escalation not found");
+
+        try
+        {
+            escalation.Approve();
+            await _escalationRepository.UpdateAsync(escalation, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success(_mapper.Map<EscalationDto>(escalation));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<EscalationDto>(ex.Message);
+        }
+    }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/ApproveEscalation/ApproveEscalationCommandValidator.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/ApproveEscalation/ApproveEscalationCommandValidator.cs
@@ -1,0 +1,11 @@
+namespace TelecomPM.Application.Commands.Escalations.ApproveEscalation;
+
+using FluentValidation;
+
+public class ApproveEscalationCommandValidator : AbstractValidator<ApproveEscalationCommand>
+{
+    public ApproveEscalationCommandValidator()
+    {
+        RuleFor(x => x.EscalationId).NotEmpty();
+    }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/CloseEscalation/CloseEscalationCommand.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/CloseEscalation/CloseEscalationCommand.cs
@@ -1,0 +1,9 @@
+namespace TelecomPM.Application.Commands.Escalations.CloseEscalation;
+
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.Escalations;
+
+public record CloseEscalationCommand : ICommand<EscalationDto>
+{
+    public Guid EscalationId { get; init; }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/CloseEscalation/CloseEscalationCommandHandler.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/CloseEscalation/CloseEscalationCommandHandler.cs
@@ -1,0 +1,45 @@
+namespace TelecomPM.Application.Commands.Escalations.CloseEscalation;
+
+using AutoMapper;
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.Escalations;
+using TelecomPM.Domain.Exceptions;
+using TelecomPM.Domain.Interfaces.Repositories;
+
+public class CloseEscalationCommandHandler : IRequestHandler<CloseEscalationCommand, Result<EscalationDto>>
+{
+    private readonly IEscalationRepository _escalationRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMapper _mapper;
+
+    public CloseEscalationCommandHandler(
+        IEscalationRepository escalationRepository,
+        IUnitOfWork unitOfWork,
+        IMapper mapper)
+    {
+        _escalationRepository = escalationRepository;
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<EscalationDto>> Handle(CloseEscalationCommand request, CancellationToken cancellationToken)
+    {
+        var escalation = await _escalationRepository.GetByIdAsync(request.EscalationId, cancellationToken);
+        if (escalation is null)
+            return Result.Failure<EscalationDto>("Escalation not found");
+
+        try
+        {
+            escalation.Close();
+            await _escalationRepository.UpdateAsync(escalation, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success(_mapper.Map<EscalationDto>(escalation));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<EscalationDto>(ex.Message);
+        }
+    }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/CloseEscalation/CloseEscalationCommandValidator.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/CloseEscalation/CloseEscalationCommandValidator.cs
@@ -1,0 +1,11 @@
+namespace TelecomPM.Application.Commands.Escalations.CloseEscalation;
+
+using FluentValidation;
+
+public class CloseEscalationCommandValidator : AbstractValidator<CloseEscalationCommand>
+{
+    public CloseEscalationCommandValidator()
+    {
+        RuleFor(x => x.EscalationId).NotEmpty();
+    }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/RejectEscalation/RejectEscalationCommand.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/RejectEscalation/RejectEscalationCommand.cs
@@ -1,0 +1,9 @@
+namespace TelecomPM.Application.Commands.Escalations.RejectEscalation;
+
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.Escalations;
+
+public record RejectEscalationCommand : ICommand<EscalationDto>
+{
+    public Guid EscalationId { get; init; }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/RejectEscalation/RejectEscalationCommandHandler.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/RejectEscalation/RejectEscalationCommandHandler.cs
@@ -1,0 +1,45 @@
+namespace TelecomPM.Application.Commands.Escalations.RejectEscalation;
+
+using AutoMapper;
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.Escalations;
+using TelecomPM.Domain.Exceptions;
+using TelecomPM.Domain.Interfaces.Repositories;
+
+public class RejectEscalationCommandHandler : IRequestHandler<RejectEscalationCommand, Result<EscalationDto>>
+{
+    private readonly IEscalationRepository _escalationRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMapper _mapper;
+
+    public RejectEscalationCommandHandler(
+        IEscalationRepository escalationRepository,
+        IUnitOfWork unitOfWork,
+        IMapper mapper)
+    {
+        _escalationRepository = escalationRepository;
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<EscalationDto>> Handle(RejectEscalationCommand request, CancellationToken cancellationToken)
+    {
+        var escalation = await _escalationRepository.GetByIdAsync(request.EscalationId, cancellationToken);
+        if (escalation is null)
+            return Result.Failure<EscalationDto>("Escalation not found");
+
+        try
+        {
+            escalation.Reject();
+            await _escalationRepository.UpdateAsync(escalation, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success(_mapper.Map<EscalationDto>(escalation));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<EscalationDto>(ex.Message);
+        }
+    }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/RejectEscalation/RejectEscalationCommandValidator.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/RejectEscalation/RejectEscalationCommandValidator.cs
@@ -1,0 +1,11 @@
+namespace TelecomPM.Application.Commands.Escalations.RejectEscalation;
+
+using FluentValidation;
+
+public class RejectEscalationCommandValidator : AbstractValidator<RejectEscalationCommand>
+{
+    public RejectEscalationCommandValidator()
+    {
+        RuleFor(x => x.EscalationId).NotEmpty();
+    }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/ReviewEscalation/ReviewEscalationCommand.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/ReviewEscalation/ReviewEscalationCommand.cs
@@ -1,0 +1,9 @@
+namespace TelecomPM.Application.Commands.Escalations.ReviewEscalation;
+
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.Escalations;
+
+public record ReviewEscalationCommand : ICommand<EscalationDto>
+{
+    public Guid EscalationId { get; init; }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/ReviewEscalation/ReviewEscalationCommandHandler.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/ReviewEscalation/ReviewEscalationCommandHandler.cs
@@ -1,0 +1,45 @@
+namespace TelecomPM.Application.Commands.Escalations.ReviewEscalation;
+
+using AutoMapper;
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.Escalations;
+using TelecomPM.Domain.Exceptions;
+using TelecomPM.Domain.Interfaces.Repositories;
+
+public class ReviewEscalationCommandHandler : IRequestHandler<ReviewEscalationCommand, Result<EscalationDto>>
+{
+    private readonly IEscalationRepository _escalationRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMapper _mapper;
+
+    public ReviewEscalationCommandHandler(
+        IEscalationRepository escalationRepository,
+        IUnitOfWork unitOfWork,
+        IMapper mapper)
+    {
+        _escalationRepository = escalationRepository;
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<EscalationDto>> Handle(ReviewEscalationCommand request, CancellationToken cancellationToken)
+    {
+        var escalation = await _escalationRepository.GetByIdAsync(request.EscalationId, cancellationToken);
+        if (escalation is null)
+            return Result.Failure<EscalationDto>("Escalation not found");
+
+        try
+        {
+            escalation.MarkUnderReview();
+            await _escalationRepository.UpdateAsync(escalation, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success(_mapper.Map<EscalationDto>(escalation));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<EscalationDto>(ex.Message);
+        }
+    }
+}

--- a/src/TelecomPm.Application/Commands/Escalations/ReviewEscalation/ReviewEscalationCommandValidator.cs
+++ b/src/TelecomPm.Application/Commands/Escalations/ReviewEscalation/ReviewEscalationCommandValidator.cs
@@ -1,0 +1,11 @@
+namespace TelecomPM.Application.Commands.Escalations.ReviewEscalation;
+
+using FluentValidation;
+
+public class ReviewEscalationCommandValidator : AbstractValidator<ReviewEscalationCommand>
+{
+    public ReviewEscalationCommandValidator()
+    {
+        RuleFor(x => x.EscalationId).NotEmpty();
+    }
+}

--- a/tests/TelecomPM.Application.Tests/Services/ApiAuthorizationPoliciesTests.cs
+++ b/tests/TelecomPM.Application.Tests/Services/ApiAuthorizationPoliciesTests.cs
@@ -38,7 +38,6 @@ public class ApiAuthorizationPoliciesTests
     [Theory]
     [InlineData(typeof(VisitsController), ApiAuthorizationPolicies.CanReviewVisits)]
     [InlineData(typeof(EscalationsController), ApiAuthorizationPolicies.CanManageEscalations)]
-    [InlineData(typeof(EscalationsController), ApiAuthorizationPolicies.CanViewEscalations)]
     [InlineData(typeof(KpiController), ApiAuthorizationPolicies.CanViewKpis)]
     [InlineData(typeof(UsersController), ApiAuthorizationPolicies.CanManageUsers)]
     [InlineData(typeof(OfficesController), ApiAuthorizationPolicies.CanManageOffices)]

--- a/tests/TelecomPM.Domain.Tests/Entities/EscalationTests.cs
+++ b/tests/TelecomPM.Domain.Tests/Entities/EscalationTests.cs
@@ -45,4 +45,74 @@ public class EscalationTests
 
         act.Should().Throw<DomainException>().WithMessage("*Evidence package is required*");
     }
+
+    [Fact]
+    public void Approve_FromSubmitted_ShouldThrow()
+    {
+        var escalation = CreateEscalation();
+
+        Action act = escalation.Approve;
+
+        act.Should().Throw<DomainException>().WithMessage("*Only under-review escalation can be approved*");
+    }
+
+    [Fact]
+    public void Reject_FromSubmitted_ShouldThrow()
+    {
+        var escalation = CreateEscalation();
+
+        Action act = escalation.Reject;
+
+        act.Should().Throw<DomainException>().WithMessage("*Only under-review escalation can be rejected*");
+    }
+
+    [Fact]
+    public void MarkUnderReview_FromApproved_ShouldThrow()
+    {
+        var escalation = CreateEscalation();
+        escalation.MarkUnderReview();
+        escalation.Approve();
+
+        Action act = escalation.MarkUnderReview;
+
+        act.Should().Throw<DomainException>().WithMessage("*Only submitted escalation can be moved to review*");
+    }
+
+    [Fact]
+    public void Close_FromSubmitted_ShouldThrow()
+    {
+        var escalation = CreateEscalation();
+
+        Action act = escalation.Close;
+
+        act.Should().Throw<DomainException>().WithMessage("*Only approved or rejected escalation can be closed*");
+    }
+
+    [Fact]
+    public void Close_AfterApproval_ShouldSetClosed()
+    {
+        var escalation = CreateEscalation();
+        escalation.MarkUnderReview();
+        escalation.Approve();
+
+        escalation.Close();
+
+        escalation.Status.Should().Be(EscalationStatus.Closed);
+    }
+
+    private static Escalation CreateEscalation()
+    {
+        return Escalation.Create(
+            Guid.NewGuid(),
+            "INC-1003",
+            "S-TNT-003",
+            SlaClass.P2,
+            1000,
+            5,
+            "photos+logs",
+            "actions",
+            "decision",
+            EscalationLevel.BMManagement,
+            "dispatcher");
+    }
 }


### PR DESCRIPTION
## What
Expose escalation state transitions via API.

## New Endpoints
- PATCH /api/escalations/{id}/review
- PATCH /api/escalations/{id}/approve
- PATCH /api/escalations/{id}/reject
- PATCH /api/escalations/{id}/close

## Changes
- EscalationsController.cs: add 4 new actions
- New commands if missing: ReviewEscalation, ApproveEscalation,
  RejectEscalation, CloseEscalation
- Domain guard tests for invalid state transitions

## Testing
- dotnet test — all tests pass