### PR TITLE
feat: expose remaining visit commands (cancel/reschedule/remove-photo/update-reading)

### DIFF
--- a/src/TelecomPm.Api/Contracts/Visits/CancelVisitRequest.cs
+++ b/src/TelecomPm.Api/Contracts/Visits/CancelVisitRequest.cs
@@ -1,0 +1,10 @@
+namespace TelecomPm.Api.Contracts.Visits;
+
+using System.ComponentModel.DataAnnotations;
+
+public record CancelVisitRequest
+{
+    [Required]
+    [MaxLength(500)]
+    public string Reason { get; init; } = string.Empty;
+}

--- a/src/TelecomPm.Api/Contracts/Visits/RescheduleVisitRequest.cs
+++ b/src/TelecomPm.Api/Contracts/Visits/RescheduleVisitRequest.cs
@@ -1,0 +1,13 @@
+namespace TelecomPm.Api.Contracts.Visits;
+
+using System;
+using System.ComponentModel.DataAnnotations;
+
+public record RescheduleVisitRequest
+{
+    [Required]
+    public DateTime NewScheduledDate { get; init; }
+
+    [MaxLength(500)]
+    public string? Reason { get; init; }
+}

--- a/src/TelecomPm.Api/Contracts/Visits/UpdateVisitReadingRequest.cs
+++ b/src/TelecomPm.Api/Contracts/Visits/UpdateVisitReadingRequest.cs
@@ -1,0 +1,9 @@
+namespace TelecomPm.Api.Contracts.Visits;
+
+using System.ComponentModel.DataAnnotations;
+
+public record UpdateVisitReadingRequest
+{
+    [Required]
+    public decimal Value { get; init; }
+}

--- a/src/TelecomPm.Api/Controllers/VisitsController.cs
+++ b/src/TelecomPm.Api/Controllers/VisitsController.cs
@@ -218,4 +218,45 @@ public sealed class VisitsController : ApiControllerBase
         var result = await Mediator.Send(request.ToCommand(visitId, stream), cancellationToken);
         return HandleResult(result);
     }
+
+    [HttpPost("{visitId:guid}/cancel")]
+    public async Task<IActionResult> Cancel(
+        Guid visitId,
+        [FromBody] CancelVisitRequest request,
+        CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(visitId), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPost("{visitId:guid}/reschedule")]
+    public async Task<IActionResult> Reschedule(
+        Guid visitId,
+        [FromBody] RescheduleVisitRequest request,
+        CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(visitId), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpDelete("{visitId:guid}/photos/{photoId:guid}")]
+    public async Task<IActionResult> RemovePhoto(
+        Guid visitId,
+        Guid photoId,
+        CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(visitId.ToRemovePhotoCommand(photoId), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPatch("{visitId:guid}/readings/{readingId:guid}")]
+    public async Task<IActionResult> UpdateReading(
+        Guid visitId,
+        Guid readingId,
+        [FromBody] UpdateVisitReadingRequest request,
+        CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(request.ToCommand(visitId, readingId), cancellationToken);
+        return HandleResult(result);
+    }
 }

--- a/src/TelecomPm.Api/Mappings/VisitsContractMapper.cs
+++ b/src/TelecomPm.Api/Mappings/VisitsContractMapper.cs
@@ -9,14 +9,18 @@ using TelecomPM.Application.Commands.Visits.AddIssue;
 using TelecomPM.Application.Commands.Visits.AddPhoto;
 using TelecomPM.Application.Commands.Visits.AddReading;
 using TelecomPM.Application.Commands.Visits.ApproveVisit;
+using TelecomPM.Application.Commands.Visits.CancelVisit;
 using TelecomPM.Application.Commands.Visits.CompleteVisit;
 using TelecomPM.Application.Commands.Visits.CreateVisit;
 using TelecomPM.Application.Commands.Visits.RejectVisit;
+using TelecomPM.Application.Commands.Visits.RemovePhoto;
 using TelecomPM.Application.Commands.Visits.RequestCorrection;
+using TelecomPM.Application.Commands.Visits.RescheduleVisit;
 using TelecomPM.Application.Commands.Visits.ResolveIssue;
 using TelecomPM.Application.Commands.Visits.StartVisit;
 using TelecomPM.Application.Commands.Visits.SubmitVisit;
 using TelecomPM.Application.Commands.Visits.UpdateChecklistItem;
+using TelecomPM.Application.Commands.Visits.UpdateReading;
 using TelecomPM.Application.Queries.Visits.GetEngineerVisits;
 using TelecomPM.Application.Queries.Visits.GetPendingReviews;
 using TelecomPM.Application.Queries.Visits.GetScheduledVisits;
@@ -170,5 +174,35 @@ public static class VisitsContractMapper
             Description = request.Description,
             Latitude = request.Latitude,
             Longitude = request.Longitude
+        };
+
+    public static CancelVisitCommand ToCommand(this CancelVisitRequest request, Guid visitId)
+        => new()
+        {
+            VisitId = visitId,
+            Reason = request.Reason
+        };
+
+    public static RescheduleVisitCommand ToCommand(this RescheduleVisitRequest request, Guid visitId)
+        => new()
+        {
+            VisitId = visitId,
+            NewScheduledDate = request.NewScheduledDate,
+            Reason = request.Reason
+        };
+
+    public static RemovePhotoCommand ToRemovePhotoCommand(this Guid visitId, Guid photoId)
+        => new()
+        {
+            VisitId = visitId,
+            PhotoId = photoId
+        };
+
+    public static UpdateReadingCommand ToCommand(this UpdateVisitReadingRequest request, Guid visitId, Guid readingId)
+        => new()
+        {
+            VisitId = visitId,
+            ReadingId = readingId,
+            Value = request.Value
         };
 }

--- a/tests/TelecomPM.Application.Tests/Commands/Visits/CancelVisitCommandHandlerTests.cs
+++ b/tests/TelecomPM.Application.Tests/Commands/Visits/CancelVisitCommandHandlerTests.cs
@@ -1,0 +1,71 @@
+using FluentAssertions;
+using Moq;
+using TelecomPM.Application.Commands.Visits.CancelVisit;
+using TelecomPM.Domain.Entities.Visits;
+using TelecomPM.Domain.Enums;
+using TelecomPM.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace TelecomPM.Application.Tests.Commands.Visits;
+
+public class CancelVisitCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenVisitExists_ShouldCancelVisitAndPersist()
+    {
+        var visit = CreateVisit();
+        var visitRepository = new Mock<IVisitRepository>();
+        visitRepository
+            .Setup(r => r.GetByIdAsync(visit.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(visit);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var handler = new CancelVisitCommandHandler(visitRepository.Object, unitOfWork.Object);
+
+        var command = new CancelVisitCommand
+        {
+            VisitId = visit.Id,
+            Reason = "Weather conditions"
+        };
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        visit.Status.Should().Be(VisitStatus.Cancelled);
+        visit.EngineerNotes.Should().Be("Weather conditions");
+        visitRepository.Verify(r => r.UpdateAsync(visit, It.IsAny<CancellationToken>()), Times.Once);
+        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenVisitDoesNotExist_ShouldReturnFailure()
+    {
+        var visitRepository = new Mock<IVisitRepository>();
+        visitRepository
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Visit?)null);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var handler = new CancelVisitCommandHandler(visitRepository.Object, unitOfWork.Object);
+
+        var result = await handler.Handle(
+            new CancelVisitCommand { VisitId = Guid.NewGuid(), Reason = "No access" },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Visit not found");
+        visitRepository.Verify(r => r.UpdateAsync(It.IsAny<Visit>(), It.IsAny<CancellationToken>()), Times.Never);
+        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static Visit CreateVisit()
+        => Visit.Create(
+            "V-5001",
+            Guid.NewGuid(),
+            "S-TNT-500",
+            "Site 500",
+            Guid.NewGuid(),
+            "Engineer Z",
+            DateTime.UtcNow.AddDays(1),
+            VisitType.PreventiveMaintenance);
+}

--- a/tests/TelecomPM.Application.Tests/Commands/Visits/RescheduleVisitCommandHandlerTests.cs
+++ b/tests/TelecomPM.Application.Tests/Commands/Visits/RescheduleVisitCommandHandlerTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using Moq;
+using TelecomPM.Application.Commands.Visits.RescheduleVisit;
+using TelecomPM.Domain.Entities.Visits;
+using TelecomPM.Domain.Enums;
+using TelecomPM.Domain.Interfaces.Repositories;
+using TelecomPM.Domain.ValueObjects;
+using Xunit;
+
+namespace TelecomPM.Application.Tests.Commands.Visits;
+
+public class RescheduleVisitCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenVisitIsScheduled_ShouldRescheduleAndPersist()
+    {
+        var visit = CreateVisit();
+        var newDate = DateTime.Today.AddDays(2);
+
+        var visitRepository = new Mock<IVisitRepository>();
+        visitRepository
+            .Setup(r => r.GetByIdAsync(visit.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(visit);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var handler = new RescheduleVisitCommandHandler(visitRepository.Object, unitOfWork.Object);
+
+        var result = await handler.Handle(
+            new RescheduleVisitCommand
+            {
+                VisitId = visit.Id,
+                NewScheduledDate = newDate,
+                Reason = "Customer requested change"
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        visit.ScheduledDate.Should().Be(newDate);
+        visitRepository.Verify(r => r.UpdateAsync(visit, It.IsAny<CancellationToken>()), Times.Once);
+        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenVisitIsNotScheduled_ShouldReturnFailure()
+    {
+        var visit = CreateVisit();
+        visit.StartVisit(Coordinates.Create(30.1, 31.2));
+
+        var visitRepository = new Mock<IVisitRepository>();
+        visitRepository
+            .Setup(r => r.GetByIdAsync(visit.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(visit);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var handler = new RescheduleVisitCommandHandler(visitRepository.Object, unitOfWork.Object);
+
+        var result = await handler.Handle(
+            new RescheduleVisitCommand
+            {
+                VisitId = visit.Id,
+                NewScheduledDate = DateTime.Today.AddDays(1),
+                Reason = "Conflict"
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Only scheduled visits can be rescheduled");
+        visitRepository.Verify(r => r.UpdateAsync(It.IsAny<Visit>(), It.IsAny<CancellationToken>()), Times.Never);
+        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static Visit CreateVisit()
+        => Visit.Create(
+            "V-6001",
+            Guid.NewGuid(),
+            "S-TNT-600",
+            "Site 600",
+            Guid.NewGuid(),
+            "Engineer Y",
+            DateTime.Today.AddDays(1),
+            VisitType.PreventiveMaintenance);
+}


### PR DESCRIPTION
## What
Expose visit commands that existed in Application layer 
but were not reachable from API.

## New Endpoints
- DELETE /api/visits/{id}                    (cancel)
- PATCH  /api/visits/{id}/schedule
- DELETE /api/visits/{id}/photos/{photoId}
- PUT    /api/visits/{id}/readings/{readingId}

## Changes
- VisitsController.cs: add 4 new actions
- Tests: add unit tests for CancelVisit and RescheduleVisit handlers

## Testing
- dotnet test — all tests pass