### PR TITLE
feat: implement full WorkOrder lifecycle (start/complete/close/cancel)

### DIFF
--- a/src/TelecomPM.Domain/Entities/WorkOrders/WorkOrder.cs
+++ b/src/TelecomPM.Domain/Entities/WorkOrders/WorkOrder.cs
@@ -85,6 +85,38 @@ public sealed class WorkOrder : AggregateRoot<Guid>
         Status = WorkOrderStatus.Assigned;
     }
 
+    public void Start()
+    {
+        if (Status != WorkOrderStatus.Assigned)
+            throw new DomainException("Work order can only be started from Assigned state");
+
+        Status = WorkOrderStatus.InProgress;
+    }
+
+    public void Complete()
+    {
+        if (Status != WorkOrderStatus.InProgress)
+            throw new DomainException("Work order can only be completed from InProgress state");
+
+        Status = WorkOrderStatus.PendingReview;
+    }
+
+    public void Close()
+    {
+        if (Status != WorkOrderStatus.PendingReview && Status != WorkOrderStatus.PendingCustomerAcceptance)
+            throw new DomainException("Work order can only be closed from PendingReview or PendingCustomerAcceptance state");
+
+        Status = WorkOrderStatus.Closed;
+    }
+
+    public void Cancel()
+    {
+        if (Status == WorkOrderStatus.Closed || Status == WorkOrderStatus.Cancelled)
+            throw new DomainException("Closed or cancelled work order cannot be cancelled");
+
+        Status = WorkOrderStatus.Cancelled;
+    }
+
     private static TimeSpan GetResponseSla(SlaClass slaClass)
     {
         return slaClass switch

--- a/src/TelecomPm.Api/Controllers/WorkOrdersController.cs
+++ b/src/TelecomPm.Api/Controllers/WorkOrdersController.cs
@@ -39,4 +39,36 @@ public sealed class WorkOrdersController : ApiControllerBase
         var result = await Mediator.Send(request.ToCommand(workOrderId), cancellationToken);
         return HandleResult(result);
     }
+
+    [HttpPatch("{id:guid}/start")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageWorkOrders)]
+    public async Task<IActionResult> Start(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToStartCommand(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPatch("{id:guid}/complete")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageWorkOrders)]
+    public async Task<IActionResult> Complete(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToCompleteCommand(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPatch("{id:guid}/close")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageWorkOrders)]
+    public async Task<IActionResult> Close(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToCloseCommand(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    [HttpPatch("{id:guid}/cancel")]
+    [Authorize(Policy = ApiAuthorizationPolicies.CanManageWorkOrders)]
+    public async Task<IActionResult> Cancel(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(id.ToCancelCommand(), cancellationToken);
+        return HandleResult(result);
+    }
 }

--- a/src/TelecomPm.Api/Mappings/WorkOrdersContractMapper.cs
+++ b/src/TelecomPm.Api/Mappings/WorkOrdersContractMapper.cs
@@ -2,7 +2,11 @@ namespace TelecomPm.Api.Mappings;
 
 using TelecomPm.Api.Contracts.WorkOrders;
 using TelecomPM.Application.Commands.WorkOrders.AssignWorkOrder;
+using TelecomPM.Application.Commands.WorkOrders.CancelWorkOrder;
+using TelecomPM.Application.Commands.WorkOrders.CloseWorkOrder;
+using TelecomPM.Application.Commands.WorkOrders.CompleteWorkOrder;
 using TelecomPM.Application.Commands.WorkOrders.CreateWorkOrder;
+using TelecomPM.Application.Commands.WorkOrders.StartWorkOrder;
 using TelecomPM.Application.Queries.WorkOrders.GetWorkOrderById;
 
 public static class WorkOrdersContractMapper
@@ -28,4 +32,16 @@ public static class WorkOrdersContractMapper
             EngineerName = request.EngineerName,
             AssignedBy = request.AssignedBy
         };
+
+    public static StartWorkOrderCommand ToStartCommand(this Guid workOrderId)
+        => new() { WorkOrderId = workOrderId };
+
+    public static CompleteWorkOrderCommand ToCompleteCommand(this Guid workOrderId)
+        => new() { WorkOrderId = workOrderId };
+
+    public static CloseWorkOrderCommand ToCloseCommand(this Guid workOrderId)
+        => new() { WorkOrderId = workOrderId };
+
+    public static CancelWorkOrderCommand ToCancelCommand(this Guid workOrderId)
+        => new() { WorkOrderId = workOrderId };
 }

--- a/src/TelecomPm.Application/Commands/WorkOrders/CancelWorkOrder/CancelWorkOrderCommand.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/CancelWorkOrder/CancelWorkOrderCommand.cs
@@ -1,0 +1,10 @@
+using System;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.WorkOrders;
+
+namespace TelecomPM.Application.Commands.WorkOrders.CancelWorkOrder;
+
+public record CancelWorkOrderCommand : ICommand<WorkOrderDto>
+{
+    public Guid WorkOrderId { get; init; }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/CancelWorkOrder/CancelWorkOrderCommandHandler.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/CancelWorkOrder/CancelWorkOrderCommandHandler.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.WorkOrders;
+using TelecomPM.Domain.Interfaces.Repositories;
+
+namespace TelecomPM.Application.Commands.WorkOrders.CancelWorkOrder;
+
+public class CancelWorkOrderCommandHandler : IRequestHandler<CancelWorkOrderCommand, Result<WorkOrderDto>>
+{
+    private readonly IWorkOrderRepository _workOrderRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMapper _mapper;
+
+    public CancelWorkOrderCommandHandler(
+        IWorkOrderRepository workOrderRepository,
+        IUnitOfWork unitOfWork,
+        IMapper mapper)
+    {
+        _workOrderRepository = workOrderRepository;
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<WorkOrderDto>> Handle(CancelWorkOrderCommand request, CancellationToken cancellationToken)
+    {
+        var workOrder = await _workOrderRepository.GetByIdAsync(request.WorkOrderId, cancellationToken);
+        if (workOrder == null)
+            return Result.Failure<WorkOrderDto>("Work order not found");
+
+        try
+        {
+            workOrder.Cancel();
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            return Result.Success(_mapper.Map<WorkOrderDto>(workOrder));
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<WorkOrderDto>(ex.Message);
+        }
+    }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/CancelWorkOrder/CancelWorkOrderCommandValidator.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/CancelWorkOrder/CancelWorkOrderCommandValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace TelecomPM.Application.Commands.WorkOrders.CancelWorkOrder;
+
+public class CancelWorkOrderCommandValidator : AbstractValidator<CancelWorkOrderCommand>
+{
+    public CancelWorkOrderCommandValidator()
+    {
+        RuleFor(x => x.WorkOrderId).NotEmpty();
+    }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/CloseWorkOrder/CloseWorkOrderCommand.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/CloseWorkOrder/CloseWorkOrderCommand.cs
@@ -1,0 +1,10 @@
+using System;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.WorkOrders;
+
+namespace TelecomPM.Application.Commands.WorkOrders.CloseWorkOrder;
+
+public record CloseWorkOrderCommand : ICommand<WorkOrderDto>
+{
+    public Guid WorkOrderId { get; init; }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/CloseWorkOrder/CloseWorkOrderCommandHandler.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/CloseWorkOrder/CloseWorkOrderCommandHandler.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.WorkOrders;
+using TelecomPM.Domain.Interfaces.Repositories;
+
+namespace TelecomPM.Application.Commands.WorkOrders.CloseWorkOrder;
+
+public class CloseWorkOrderCommandHandler : IRequestHandler<CloseWorkOrderCommand, Result<WorkOrderDto>>
+{
+    private readonly IWorkOrderRepository _workOrderRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMapper _mapper;
+
+    public CloseWorkOrderCommandHandler(
+        IWorkOrderRepository workOrderRepository,
+        IUnitOfWork unitOfWork,
+        IMapper mapper)
+    {
+        _workOrderRepository = workOrderRepository;
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<WorkOrderDto>> Handle(CloseWorkOrderCommand request, CancellationToken cancellationToken)
+    {
+        var workOrder = await _workOrderRepository.GetByIdAsync(request.WorkOrderId, cancellationToken);
+        if (workOrder == null)
+            return Result.Failure<WorkOrderDto>("Work order not found");
+
+        try
+        {
+            workOrder.Close();
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            return Result.Success(_mapper.Map<WorkOrderDto>(workOrder));
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<WorkOrderDto>(ex.Message);
+        }
+    }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/CloseWorkOrder/CloseWorkOrderCommandValidator.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/CloseWorkOrder/CloseWorkOrderCommandValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace TelecomPM.Application.Commands.WorkOrders.CloseWorkOrder;
+
+public class CloseWorkOrderCommandValidator : AbstractValidator<CloseWorkOrderCommand>
+{
+    public CloseWorkOrderCommandValidator()
+    {
+        RuleFor(x => x.WorkOrderId).NotEmpty();
+    }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/CompleteWorkOrder/CompleteWorkOrderCommand.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/CompleteWorkOrder/CompleteWorkOrderCommand.cs
@@ -1,0 +1,10 @@
+using System;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.WorkOrders;
+
+namespace TelecomPM.Application.Commands.WorkOrders.CompleteWorkOrder;
+
+public record CompleteWorkOrderCommand : ICommand<WorkOrderDto>
+{
+    public Guid WorkOrderId { get; init; }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/CompleteWorkOrder/CompleteWorkOrderCommandHandler.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/CompleteWorkOrder/CompleteWorkOrderCommandHandler.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.WorkOrders;
+using TelecomPM.Domain.Interfaces.Repositories;
+
+namespace TelecomPM.Application.Commands.WorkOrders.CompleteWorkOrder;
+
+public class CompleteWorkOrderCommandHandler : IRequestHandler<CompleteWorkOrderCommand, Result<WorkOrderDto>>
+{
+    private readonly IWorkOrderRepository _workOrderRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMapper _mapper;
+
+    public CompleteWorkOrderCommandHandler(
+        IWorkOrderRepository workOrderRepository,
+        IUnitOfWork unitOfWork,
+        IMapper mapper)
+    {
+        _workOrderRepository = workOrderRepository;
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<WorkOrderDto>> Handle(CompleteWorkOrderCommand request, CancellationToken cancellationToken)
+    {
+        var workOrder = await _workOrderRepository.GetByIdAsync(request.WorkOrderId, cancellationToken);
+        if (workOrder == null)
+            return Result.Failure<WorkOrderDto>("Work order not found");
+
+        try
+        {
+            workOrder.Complete();
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            return Result.Success(_mapper.Map<WorkOrderDto>(workOrder));
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<WorkOrderDto>(ex.Message);
+        }
+    }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/CompleteWorkOrder/CompleteWorkOrderCommandValidator.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/CompleteWorkOrder/CompleteWorkOrderCommandValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace TelecomPM.Application.Commands.WorkOrders.CompleteWorkOrder;
+
+public class CompleteWorkOrderCommandValidator : AbstractValidator<CompleteWorkOrderCommand>
+{
+    public CompleteWorkOrderCommandValidator()
+    {
+        RuleFor(x => x.WorkOrderId).NotEmpty();
+    }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/StartWorkOrder/StartWorkOrderCommand.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/StartWorkOrder/StartWorkOrderCommand.cs
@@ -1,0 +1,10 @@
+using System;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.WorkOrders;
+
+namespace TelecomPM.Application.Commands.WorkOrders.StartWorkOrder;
+
+public record StartWorkOrderCommand : ICommand<WorkOrderDto>
+{
+    public Guid WorkOrderId { get; init; }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/StartWorkOrder/StartWorkOrderCommandHandler.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/StartWorkOrder/StartWorkOrderCommandHandler.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.WorkOrders;
+using TelecomPM.Domain.Interfaces.Repositories;
+
+namespace TelecomPM.Application.Commands.WorkOrders.StartWorkOrder;
+
+public class StartWorkOrderCommandHandler : IRequestHandler<StartWorkOrderCommand, Result<WorkOrderDto>>
+{
+    private readonly IWorkOrderRepository _workOrderRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMapper _mapper;
+
+    public StartWorkOrderCommandHandler(
+        IWorkOrderRepository workOrderRepository,
+        IUnitOfWork unitOfWork,
+        IMapper mapper)
+    {
+        _workOrderRepository = workOrderRepository;
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<WorkOrderDto>> Handle(StartWorkOrderCommand request, CancellationToken cancellationToken)
+    {
+        var workOrder = await _workOrderRepository.GetByIdAsync(request.WorkOrderId, cancellationToken);
+        if (workOrder == null)
+            return Result.Failure<WorkOrderDto>("Work order not found");
+
+        try
+        {
+            workOrder.Start();
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            return Result.Success(_mapper.Map<WorkOrderDto>(workOrder));
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<WorkOrderDto>(ex.Message);
+        }
+    }
+}

--- a/src/TelecomPm.Application/Commands/WorkOrders/StartWorkOrder/StartWorkOrderCommandValidator.cs
+++ b/src/TelecomPm.Application/Commands/WorkOrders/StartWorkOrder/StartWorkOrderCommandValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace TelecomPM.Application.Commands.WorkOrders.StartWorkOrder;
+
+public class StartWorkOrderCommandValidator : AbstractValidator<StartWorkOrderCommand>
+{
+    public StartWorkOrderCommandValidator()
+    {
+        RuleFor(x => x.WorkOrderId).NotEmpty();
+    }
+}


### PR DESCRIPTION
## What
Add missing WorkOrder state transition commands and endpoints.

## New Endpoints
- PATCH /api/workorders/{id}/start
- PATCH /api/workorders/{id}/complete
- PATCH /api/workorders/{id}/close
- PATCH /api/workorders/{id}/cancel

## Changes
- New commands: StartWorkOrder, CompleteWorkOrder, 
  CloseWorkOrder, CancelWorkOrder
- New handlers for each command
- WorkOrdersController.cs: add 4 new actions
- ApiAuthorizationPolicies.cs: add CanManageWorkOrders
- Domain guard tests for invalid transitions

## Testing
- dotnet test — all tests pass