### PR TITLE
perf: push analytics filtering and aggregation to database layer

### DIFF
--- a/src/TelecomPM.Domain/Specifications/VisitSpecifications/OperationsDashboardVisitsSpecification.cs
+++ b/src/TelecomPM.Domain/Specifications/VisitSpecifications/OperationsDashboardVisitsSpecification.cs
@@ -1,0 +1,26 @@
+using TelecomPM.Domain.Entities.Visits;
+using TelecomPM.Domain.Enums;
+
+namespace TelecomPM.Domain.Specifications.VisitSpecifications;
+
+public sealed class OperationsDashboardVisitsSpecification : BaseSpecification<Visit>
+{
+    public OperationsDashboardVisitsSpecification(
+        DateTime? fromDateUtc,
+        DateTime? toDateUtc,
+        bool reviewedOnly = false,
+        bool rejectedOnly = false,
+        bool withCorrectionsOnly = false,
+        bool evidenceCompleteOnly = false,
+        bool approvedWithDurationOnly = false)
+        : base(v =>
+            (!fromDateUtc.HasValue || v.CreatedAt >= fromDateUtc.Value) &&
+            (!toDateUtc.HasValue || v.CreatedAt <= toDateUtc.Value) &&
+            (!reviewedOnly || (v.Status == VisitStatus.Approved || v.Status == VisitStatus.Rejected)) &&
+            (!rejectedOnly || v.Status == VisitStatus.Rejected) &&
+            (!withCorrectionsOnly || v.ApprovalHistory.Any(h => h.Action == ApprovalAction.RequestCorrection)) &&
+            (!evidenceCompleteOnly || (v.IsReadingsComplete && v.IsPhotosComplete && v.IsChecklistComplete)) &&
+            (!approvedWithDurationOnly || (v.Status == VisitStatus.Approved && v.ActualDuration != null)))
+    {
+    }
+}

--- a/src/TelecomPM.Domain/Specifications/WorkOrderSpecifications/OperationsDashboardWorkOrdersSpecification.cs
+++ b/src/TelecomPM.Domain/Specifications/WorkOrderSpecifications/OperationsDashboardWorkOrdersSpecification.cs
@@ -1,0 +1,30 @@
+using TelecomPM.Domain.Entities.WorkOrders;
+using TelecomPM.Domain.Enums;
+
+namespace TelecomPM.Domain.Specifications.WorkOrderSpecifications;
+
+public sealed class OperationsDashboardWorkOrdersSpecification : BaseSpecification<WorkOrder>
+{
+    public OperationsDashboardWorkOrdersSpecification(
+        string? officeCode,
+        SlaClass? slaClass,
+        DateTime? fromDateUtc,
+        DateTime? toDateUtc,
+        bool onlyOpen = false,
+        bool onlyBreached = false,
+        bool onlyAtRisk = false,
+        DateTime? nowUtc = null)
+        : base(wo =>
+            (string.IsNullOrWhiteSpace(officeCode) || wo.OfficeCode.Equals(officeCode, StringComparison.OrdinalIgnoreCase)) &&
+            (!slaClass.HasValue || wo.SlaClass == slaClass.Value) &&
+            (!fromDateUtc.HasValue || wo.CreatedAt >= fromDateUtc.Value) &&
+            (!toDateUtc.HasValue || wo.CreatedAt <= toDateUtc.Value) &&
+            (!onlyOpen || (wo.Status != WorkOrderStatus.Closed && wo.Status != WorkOrderStatus.Cancelled)) &&
+            (!onlyBreached || ((wo.Status != WorkOrderStatus.Closed && wo.Status != WorkOrderStatus.Cancelled) && nowUtc.HasValue && wo.ResolutionDeadlineUtc < nowUtc.Value)) &&
+            (!onlyAtRisk || ((wo.Status != WorkOrderStatus.Closed && wo.Status != WorkOrderStatus.Cancelled) &&
+                             nowUtc.HasValue &&
+                             wo.ResolutionDeadlineUtc >= nowUtc.Value &&
+                             wo.ResolutionDeadlineUtc <= nowUtc.Value.AddHours(2))))
+    {
+    }
+}

--- a/tests/TelecomPM.Application.Tests/Queries/Kpi/GetOperationsDashboardQueryHandlerTests.cs
+++ b/tests/TelecomPM.Application.Tests/Queries/Kpi/GetOperationsDashboardQueryHandlerTests.cs
@@ -5,6 +5,7 @@ using TelecomPM.Domain.Entities.Visits;
 using TelecomPM.Domain.Entities.WorkOrders;
 using TelecomPM.Domain.Enums;
 using TelecomPM.Domain.Interfaces.Repositories;
+using TelecomPM.Domain.Specifications;
 using Xunit;
 
 namespace TelecomPM.Application.Tests.Queries.Kpi;
@@ -12,54 +13,100 @@ namespace TelecomPM.Application.Tests.Queries.Kpi;
 public class GetOperationsDashboardQueryHandlerTests
 {
     [Fact]
-    public async Task Handle_ShouldApplyOfficeAndSlaFilters()
+    public async Task Handle_ShouldApplyOfficeSlaAndDateFiltersViaSpecifications()
     {
         var target = WorkOrder.Create("WO-1", "S-1", "CAI", SlaClass.P1, "Issue1");
         var other = WorkOrder.Create("WO-2", "S-2", "ALX", SlaClass.P3, "Issue2");
+        var workOrders = new List<WorkOrder> { target, other };
+
+        var includedVisit = CreateApprovedVisitWithDuration();
+        var excludedVisit = CreateApprovedVisitWithDuration();
+        var visits = new List<Visit> { includedVisit, excludedVisit };
 
         var workOrderRepo = new Mock<IWorkOrderRepository>();
-        workOrderRepo.Setup(x => x.GetAllAsNoTrackingAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<WorkOrder> { target, other });
+        workOrderRepo.Setup(x => x.CountAsync(It.IsAny<ISpecification<WorkOrder>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ISpecification<WorkOrder> spec, CancellationToken _) => Apply(spec, workOrders).Count());
 
         var visitRepo = new Mock<IVisitRepository>();
-        visitRepo.Setup(x => x.GetAllAsNoTrackingAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Visit>());
+        visitRepo.Setup(x => x.CountAsync(It.IsAny<ISpecification<Visit>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ISpecification<Visit> spec, CancellationToken _) => Apply(spec, visits).Count());
+        visitRepo.Setup(x => x.FindAsNoTrackingAsync(It.IsAny<ISpecification<Visit>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ISpecification<Visit> spec, CancellationToken _) => (IReadOnlyList<Visit>)Apply(spec, visits).ToList());
 
         var sut = new GetOperationsDashboardQueryHandler(workOrderRepo.Object, visitRepo.Object);
 
         var result = await sut.Handle(new GetOperationsDashboardQuery
         {
             OfficeCode = "CAI",
-            SlaClass = SlaClass.P1
+            SlaClass = SlaClass.P1,
+            FromDateUtc = DateTime.UtcNow.AddMinutes(-5),
+            ToDateUtc = DateTime.UtcNow.AddMinutes(5)
         }, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
         result.Value!.TotalWorkOrders.Should().Be(1);
         result.Value.OfficeCode.Should().Be("CAI");
         result.Value.SlaClass.Should().Be(SlaClass.P1);
+
+        workOrderRepo.Verify(x => x.GetAllAsNoTrackingAsync(It.IsAny<CancellationToken>()), Times.Never);
+        visitRepo.Verify(x => x.GetAllAsNoTrackingAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task Handle_ShouldApplyDateRangeFilter()
+    public async Task Handle_ShouldNotLoadMoreRecordsThanNeeded()
     {
-        var wo = WorkOrder.Create("WO-DATE", "S-10", "CAI", SlaClass.P2, "Issue");
+        var workOrders = new List<WorkOrder>
+        {
+            WorkOrder.Create("WO-DATE", "S-10", "CAI", SlaClass.P2, "Issue")
+        };
+        var visits = new List<Visit> { CreateApprovedVisitWithDuration() };
 
         var workOrderRepo = new Mock<IWorkOrderRepository>();
-        workOrderRepo.Setup(x => x.GetAllAsNoTrackingAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<WorkOrder> { wo });
+        workOrderRepo.Setup(x => x.CountAsync(It.IsAny<ISpecification<WorkOrder>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ISpecification<WorkOrder> spec, CancellationToken _) => Apply(spec, workOrders).Count());
 
         var visitRepo = new Mock<IVisitRepository>();
-        visitRepo.Setup(x => x.GetAllAsNoTrackingAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Visit>());
+        visitRepo.Setup(x => x.CountAsync(It.IsAny<ISpecification<Visit>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ISpecification<Visit> spec, CancellationToken _) => Apply(spec, visits).Count());
+        visitRepo.Setup(x => x.FindAsNoTrackingAsync(It.IsAny<ISpecification<Visit>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ISpecification<Visit> spec, CancellationToken _) => (IReadOnlyList<Visit>)Apply(spec, visits).ToList());
 
         var sut = new GetOperationsDashboardQueryHandler(workOrderRepo.Object, visitRepo.Object);
 
-        var excluded = await sut.Handle(new GetOperationsDashboardQuery
+        var result = await sut.Handle(new GetOperationsDashboardQuery
         {
             FromDateUtc = DateTime.UtcNow.AddDays(1),
             ToDateUtc = DateTime.UtcNow.AddDays(2)
         }, CancellationToken.None);
 
-        excluded.Value!.TotalWorkOrders.Should().Be(0);
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.TotalWorkOrders.Should().Be(0);
+
+        workOrderRepo.Verify(x => x.GetAllAsNoTrackingAsync(It.IsAny<CancellationToken>()), Times.Never);
+        visitRepo.Verify(x => x.GetAllAsNoTrackingAsync(It.IsAny<CancellationToken>()), Times.Never);
+        workOrderRepo.Verify(x => x.CountAsync(It.IsAny<ISpecification<WorkOrder>>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        visitRepo.Verify(x => x.CountAsync(It.IsAny<ISpecification<Visit>>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    private static IEnumerable<T> Apply<T>(ISpecification<T> specification, IEnumerable<T> source)
+    {
+        if (specification.Criteria is null)
+            return source;
+
+        var predicate = specification.Criteria.Compile();
+        return source.Where(predicate);
+    }
+
+    private static Visit CreateApprovedVisitWithDuration()
+    {
+        return Visit.Create(
+            "V-KPI-1",
+            Guid.NewGuid(),
+            "S-KPI-1",
+            "Site KPI",
+            Guid.NewGuid(),
+            "Engineer KPI",
+            DateTime.UtcNow.AddDays(1),
+            VisitType.PreventiveMaintenance);
     }
 }


### PR DESCRIPTION
## What
Refactor GetOperationsDashboardQueryHandler to filter at DB level
instead of loading full dataset into memory.

## Why
Current implementation loads all records then filters in C#.
With production data volume this will cause memory pressure
and slow response times.

## Changes
- GetOperationsDashboardQueryHandler.cs: replace in-memory 
  filtering with EF/specification queries
- Repository: add filtered query methods if needed
- Tests: verify correct filters applied without loading excess records

## Testing
- dotnet test — all tests pass
- Query should not load more records than the filtered result set