### PR TITLE
feat/enhancement-research-report2

### DIFF
--- a/docs/Api-Doc.md
+++ b/docs/Api-Doc.md
@@ -152,6 +152,7 @@ Related: operational process and lifecycle diagrams are documented in `docs/Oper
 - `PATCH /workorders/{id}/reject` (**CanViewPortal**)
 - `GET /sla-report` (**CanViewPortal**)
 - `GET /visits/{siteCode}` (**CanViewPortal**)
+- `GET /visits/{visitId}/evidence` (**CanViewPortal**)
 
 ### `DailyPlansController` (`/api/daily-plans`)
 - `POST /` (**CanManageSites**)

--- a/docs/_tmp_research_report_extracted.txt
+++ b/docs/_tmp_research_report_extracted.txt
@@ -1,0 +1,570 @@
+﻿DEEP RESEARCH REPORT
+Telecom Tower PM/CM Workflow Systems
+Egyptian & MENA Market — Field Service Management Analysis
+Prepared: February 2026  |  Scope: PM/CM Lifecycle, SLA, BTS Checklists, FSM Systems, KPIs
+EXECUTIVE SUMMARY
+Key findings at a glance
+This report synthesizes deep research across telecom tower operators (Orange Egypt, Vodafone Egypt, IHS Towers), global managed services providers (Ericsson, Nokia), and leading FSM platforms (IBM Maximo, SAP PM, ServiceNow FSM) to define best-practice preventive maintenance (PM) and corrective maintenance (CM) workflows applicable to the Egyptian and MENA telecom market.
+Key findings: Work order lifecycle in enterprise FSM tools follows a well-documented multi-state model (WAPPR → APPR → INPRG → COMP → CLOSE in Maximo; or the SAP S/4HANA 9-phase model). Egyptian operators primarily use subcontractor management through SLA-driven contracts with P1–P4 priority classes. BTS PM visits require standardized evidence packages (GPS-stamped photos, measurement readings, signed reports). Mobile offline-first architectures are now essential for remote sites. Battery Discharge Tests (BDT) are typically a distinct scheduled workflow within the PM calendar. Contractor KPI scorecards center on First-Time-Fix Rate, MTTR, SLA Compliance %, and Evidence Completeness.
+RESEARCH QUESTION 1: WORK ORDER LIFECYCLE
+Status States, Transitions, Triggers, Acceptance Flow, Emergency WOs
+Industry Standard — IBM Maximo Work Order Status Model
+IBM Maximo is the most widely deployed enterprise asset management platform in telecom. Its work order lifecycle defines the following canonical status states:
+Status Code
+Name
+Description
+Triggered By
+WAPPR
+Waiting Approval
+WO created but not yet approved. No work can start.
+System / Planner
+APPR / WSCH
+Approved / Waiting Scheduling
+WO approved; ready to be scheduled and assigned to a technician.
+Supervisor
+WPCOND
+Waiting Plant Condition
+WO approved but plant/site conditions prevent work (e.g., site access locked).
+Engineer / System
+WMATL
+Waiting on Material
+Work paused; awaiting spare parts or materials.
+Engineer
+INPRG
+In Progress
+Active work ongoing at site. Clock running. SLA timer tracking.
+Engineer (GPS check-in)
+COMP
+Completed
+Field work done. Report submitted. Awaiting supervisor sign-off.
+Engineer
+CLOSE
+Closed
+All approvals done. WO archived. Costs settled.
+Supervisor / System
+CAN
+Cancelled
+WO voided (only from WAPPR; cannot cancel In Progress).
+Manager
+DEFERRED
+Deferred
+WO postponed (rare; used in some Maximo configurations).
+Supervisor
+SAP PM — S/4HANA 9-Phase Model (2021+)
+SAP introduced a structured 9-phase model for maintenance order processing in S/4HANA 2021. This is increasingly adopted by large telecom operators running SAP ERP:
+Phase 1: Create Notification — technician or system logs fault/request
+Phase 2: Evaluate Notification — planner reviews; decides PM or CM
+Phase 3: Create Order — maintenance order generated from notification
+Phase 4: Plan Order — resources, materials, labor planned
+Phase 5: Cost Approval — flexible workflow triggers cost approval if order exceeds threshold
+Phase 6: Release Order — order released; work permit/clearance issued
+Phase 7: Execute Order — technician carries out work; time confirmations
+Phase 8: Complete Order — technical completion (TECO) recorded
+Phase 9: Close Order — settlement and archiving
+Egyptian/MENA Practice
+Egyptian telecom operators (Orange Egypt, Vodafone Egypt, e& Egypt) and tower companies (IHS Towers Egypt, TASC Towers) work predominantly through subcontractor ecosystems. The typical FSM workflow adapts global platforms with local business rules:
+Most Egyptian operators use a simplified 5–7 state model rather than the full Maximo or SAP phase model.
+Typical states in local deployments: New → Assigned → InProgress → PendingReview → Approved/Rejected → Closed
+A 'ReOpen' or 'Rework' state is commonly triggered when a supervisor rejects the visit report (evidence deemed incomplete, GPS mismatch, incorrect readings).
+'PendingClientAcceptance' may be added as a state between Approved and Closed when the MNO client (e.g., Orange Egypt) must sign off on tower infrastructure work.
+Emergency/Reactive WOs (CM/BM) are differentiated from planned PM WOs by a separate Work Type flag or Work Order Type, and carry a higher priority class (P1/P2) with automatic SLA clock start.
+In Ericsson-managed networks (Ericsson Operations Engine), alarm-triggered WOs from NMS/OSS are automatically created as CM tickets and routed to field teams through the NOC, bypassing manual creation.
+ReOpen / Rework State Conditions
+A Rework or ReOpen state is triggered when:
+Supervisor review finds missing evidence (photos, readings not submitted)
+GPS check-in location does not match site coordinates within allowed radius
+Readings are outside acceptable ranges without explanation
+Client portal rejects work order (PendingAcceptance → Reject path)
+Follow-up corrective action is needed from a PM visit finding
+NOTE: In Maximo, there is no native 'Rework' status. It is implemented via custom User Status or by reopening the WO from COMP back to WAPPR/APPR. In SAP PM, a rejected cost approval restarts the flexible workflow. Custom FSM tools (ServiceNow FSM, ClickSoftware) typically implement ReOpen as a first-class status.
+Customer Acceptance Flow
+For managed services contracts (e.g., Ericsson/Nokia managing on behalf of Orange Egypt or Vodafone Egypt):
+Engineer submits completed WO with evidence package (photos, measurements, GPS)
+First-line supervisor reviews and approves internally → Status: PendingClientAcceptance
+Client portal is updated; MNO client can view evidence, accept or reject
+On acceptance → Status: Closed (costs settled, KPIs updated)
+On rejection → Status: ReOpen with mandatory rejection reason; SLA clock may resume
+Key Differences: Egypt vs Global
+Global: 8–9 status states in Maximo/SAP with automated workflow transitions. Egypt: Often simplified to 5–6 states in custom mobile apps.
+Global: Client acceptance is optional/portal-based. Egypt: Operator client approval is contractually mandatory before invoice submission.
+Global: Emergency WOs separated by incident management (ITIL). Egypt: CM/BM WOs created from NMS alarm feeds manually filtered by NOC teams; automation is less mature.
+Sources
+IBM Maximo Allowable Status Changes for Work Orders — ibm.com/support
+IBM Maximo Manage Work Order Statuses Documentation — ibm.com/docs/maximo-manage
+SAP PM Flexible Workflow for Maintenance Orders — SAP Community blog (Oct 2025)
+Maximo Secrets: Work Orders Role Based Application — maximosecrets.com
+Ericsson Operations Engine / Managed Network Services — ericsson.com
+GAP: No public documentation found for Orange Egypt, Vodafone Egypt, or IHS Towers Egypt's specific internal FSM status models. Primary research (interviews, vendor demos) required to confirm.
+RESEARCH QUESTION 2: SLA & PRIORITY CLASSES
+Priority Matrix, Response Times, Breach Tracking, At-Risk Alerts
+Industry Standard — Priority Classification
+The global telecom industry uses a four-tier priority model aligned to ITIL and TM Forum standards:
+Priority
+Name
+Definition
+Response Time
+Resolution
+Escalation
+P1
+Critical
+Site fully down; 100% traffic lost. Service outage.
+15–30 min
+2–4 hours
+NOC → Manager → CTO
+P2
+High
+Partial outage; >50% capacity degraded. Battery low.
+1–2 hours
+8 hours
+NOC → Supervisor
+P3
+Medium
+Single component degraded; capacity <50% affected.
+4 hours
+24 hours
+Team lead
+P4
+Low
+Minor issue; cosmetic, non-impacting. Scheduled PM task.
+1 business day
+5 business days
+Standard queue
+Egyptian/MENA Telecom PM Specifics
+Egyptian telecom SLAs typically follow the NTRA (National Telecom Regulatory Authority) licensing requirements, which mandate certain network availability thresholds.
+BTS Site SLAs (from industry knowledge): P1 (site fully down): respond 1–4 hrs depending on urban/rural; restore within 4–8 hrs. P2 (partial): respond 4 hrs; restore 24 hrs. P3 (degraded): 24 hrs response; 72 hrs resolution. P4 (PM due): next scheduled window (weekly/monthly).
+Tower infrastructure SLAs (IHS Towers-style): Tower structural issues → P2; Power system fault → P1 or P2 depending on backup availability; Generator fuel exhaustion → P1.
+Battery-related alarms: Low battery threshold typically triggers P2; imminent discharge (LLVD alarm) triggers P1.
+IHS Towers Egypt uses a Power-as-a-Service (PaaS) model where energy SLAs (uptime guarantees) are separate from structural maintenance SLAs.
+SLA Breach Calculation & At-Risk Alerts
+SLA clock starts from the moment the WO is Created (for CM/BM reactive) or the Scheduled Date (for PM).
+At-Risk threshold: Typically 75–80% of the SLA window elapsed triggers an alert to the supervisor. E.g., for a 4-hour P2 response SLA, at-risk alert fires at 3 hours.
+SLA breach is calculated as: (Actual Resolution Time - SLA Commitment Time). Any positive value is a breach.
+Business hours vs 24/7: P1 and P2 are 24/7. P3 and P4 are typically business hours only in Egyptian market.
+SLA clock pause conditions: Waiting for MNO access permission, awaiting spare parts (WMATL state), force majeure (sandstorm, flood).
+NOTE: Egyptian market specificity: Sandy/dusty conditions (especially Upper Egypt) are commonly cited as force majeure clauses in maintenance contracts, allowing SLA clock suspension during khamsin season.
+BTS vs Tower Infrastructure SLA Differences
+BTS (Base Transceiver Station) SLAs: Driven by NMS alarm priority; typically 2–4 hr response for outages.
+Tower Infrastructure SLAs: Driven by safety and structural concerns; may have 8–24 hr response for non-critical issues.
+Power/Energy SLAs: Most critical; fuel, battery, and rectifier faults are often P1 due to potential for complete site blackout.
+Sources
+Freshworks: SLA Response Time Complete Guide — freshworks.com
+Rootly: Incident Response Support Levels P1/P2/P3 — rootly.com
+NetSuite: 23 Critical Telecom KPIs — netsuite.com
+BMC Software: 6 SLA Best Practices — bmc.com/blogs/sla-best-practices
+NTRA Egypt (National Telecom Regulatory Authority): Licensing terms reference
+GAP: No publicly available Orange Egypt, Vodafone Egypt, or IHS Towers Egypt SLA contract terms. Primary research required. NTRA published documents may contain minimum uptime mandates.
+RESEARCH QUESTION 3: VISIT / SITE INSPECTION WORKFLOW
+PM Checklist, Photo Requirements, Measurements, GPS, Evidence Validation
+Industry Standard — BTS PM Visit Checklist Structure
+Based on industry-standard telecom PM routines for BTS and MW sites (Huawei, Ericsson, Nokia equipment), a standard PM visit includes the following checklist domains:
+Domain
+Checklist Items
+Power Check
+LLVD/BLVD thresholds, site load (kW/A), lugs condition, CB trip sensor alarms, rectifier module status, AC input voltage, DC bus voltage, current per string.
+Battery System
+Float voltage per string, individual cell voltages (if flooded), battery temperature, float current, capacity estimate, visual inspection for swelling/leakage, battery age vs. replacement schedule.
+Rectifier/Power
+Rectifier module count vs. active, load sharing balance, output voltage accuracy, efficiency check, alarm status.
+Generator (if present)
+Fuel level, oil level, coolant, battery starter, run test (typically 15–30 min load test), ATS switchover test, fuel consumption log.
+Cooling/HVAC
+AC unit operation, temperature setpoint, air filter condition (clean/replace), external unit fins, condensate drain, shelter temperature log.
+BTS Equipment
+BBU active alarms, history alarms, active card status (GTMU/UMPT/LMPT), fan unit check, antenna VSWR reading, RFU/RTN status, active calls/data throughput check.
+Microwave (if present)
+RSL (Receive Signal Level) vs. nominal, XPD (Cross-Polar Discrimination), active alarms on IDU, history alarms, performance monitoring (PMON) errors.
+Civil/Structural
+Tower visual inspection, guy wire tension (guyed towers), grounding measurement (earth resistance <5 ohm), lightning rod condition, fence integrity, access road, drainage.
+Cleaning
+BBU/RTN/NE40 fan blowout, shelter floor sweep, equipment cabinet blowout, BTS filter removal and cleaning, external unit fins cleaning.
+Labeling/Cabling
+Rectifier CB labels, DCDU I/O cable labels, BBU alarm cable labeling, fiber labeling, dismantled material tagging.
+Safety/Security
+Door lock condition, security camera (if present), perimeter fence, tower light operation, hazard signage, fire extinguisher inspection.
+Photo Requirements
+Standard: Minimum 10–20 photos per PM visit. Some operators require up to 30+ for major sites.
+Mandatory photo categories: Site entrance/signage (arrival proof), shelter exterior (4 sides), equipment racks (front view), battery strings, rectifier panel, AC unit, generator fuel gauge, generator run log, grounding connection, any fault/finding found, post-repair evidence if corrective action taken.
+Photos must be GPS-stamped with coordinates and timestamp embedded in EXIF data.
+Before/after photos: Required for any cleaning or corrective action taken during PM visit.
+Photos are uploaded in real-time via mobile app (if network available) or queued for sync on return to coverage area.
+Mandatory Measurements and Readings
+Electrical: DC bus voltage (typically -48V nominal), AC input voltage (220V/380V), rectifier output current, battery string current, float voltage per string (2.27Vpc for VRLA), individual cell voltages (quarterly).
+RF/Antenna: VSWR (Voltage Standing Wave Ratio) — alert threshold typically >1.5:1, alarm >2:1. Measured via BBU alarm or external VSWR meter.
+Grounding: Earth resistance measurement — standard: <5 ohm (NFPA 780/IEC 62305); alert: >5 ohm; replace grounding: >10 ohm.
+Temperature: Shelter ambient temperature, battery string temperature (alert if >35°C), equipment inlet temperature.
+Generator: Fuel level (%), oil pressure (bar), coolant temperature, run hours since last service, ATS transfer time (seconds).
+Microwave RSL: Measured against nominal design RSL; fade margin must be maintained per link plan.
+GPS Check-In / Check-Out Enforcement
+Industry standard: Engineer must check in via mobile app within a configurable geofence radius (typically 50–150 meters from site coordinates).
+If engineer is outside allowed GPS radius: System may block WO status change to INPRG; supervisor is automatically notified; engineer must photograph GPS reading and submit override request with justification.
+GPS check-out: Engineer checks out when all checklist items completed; system timestamps departure; visit duration is calculated.
+GPS data is stored server-side with timestamps for audit trail. Disputes resolved by comparing GPS logs vs. visit evidence timestamps.
+Offline mode: GPS coordinates are captured from device GPS module and stored locally; synced to server when connectivity restored.
+NOTE: Sites in remote desert areas (Upper Egypt, Sinai) often have coordinate inaccuracies due to GPS drift. Operators typically use a larger radius (200–500m) for rural desert sites.
+Evidence Validation Before Supervisor Approval
+Completeness check: System validates all mandatory checklist items have responses (auto-validation).
+Photo count validation: System counts uploaded photos; blocks submission if below minimum threshold.
+Measurement range validation: Alert if readings outside normal bounds (e.g., VSWR >2, battery voltage <2.15Vpc).
+GPS validation: Cross-checks check-in GPS vs. site registered coordinates.
+Supervisor review: Manually reviews photos, readings, and checklist before approval. Can reject with comments.
+Sources
+Tech Junction: Telco BTS and MW Sites Preventive Maintenance Routines — techjunction.co
+Scribd: Preventive Maintenance Checklist for BTS (Saudi Arabia Al Kharj site)
+Scribd: Protelindo Site Maintenance Checklist — includes grounding, tower, AC, fencing
+Foresight Mobile: Field Service App Development for Telecom Infrastructure — foresightmobile.com
+allGeo: Geofencing Technology for Field Service Businesses — blog.allgeo.com
+GAP: Specific photo count requirements per operator are not publicly documented. No Orange Egypt or Vodafone Egypt PM checklists found publicly. Industry interviews needed.
+RESEARCH QUESTION 4: PREVENTIVE vs CORRECTIVE MAINTENANCE
+BM/CM vs PM Definitions, Separate Workflows, Escalation, BDT
+Industry Standard Definitions (EN 13306)
+The European standard EN 13306 (adopted by Egyptian NTRA as reference) defines:
+Preventive Maintenance (PM): Maintenance carried out at predetermined intervals or based on prescribed criteria, aimed at reducing the probability of failure or degradation of an item's function.
+Corrective Maintenance (CM) / Breakdown Maintenance (BM): Maintenance carried out after fault recognition, intended to restore an item to a state in which it can perform its required function.
+Predictive Maintenance (PdM): Based on condition monitoring and analysis; not yet widely deployed in Egyptian BTS PM due to capital investment requirements.
+Egyptian/MENA Practice — PM vs CM Differentiation
+PM visits: Scheduled, time-based (monthly, quarterly, semi-annual, annual). Generated automatically from PM calendar. WO Type = PM.
+CM/BM visits: Reactive, triggered by NMS alarm, NOC escalation, or field report. WO Type = CM or BM. Priority class is P1–P2 typically.
+Both are tracked as separate work order types with distinct workflows, approval chains, and SLA clocks.
+PM visits that discover faults: Engineer flags finding in PM report. System (or supervisor) creates a child CM work order linked to the parent PM WO. This preserves audit trail.
+First Line Maintenance (FLM): In Egyptian subcontractor market, FLM is the term for reactive field intervention — dispatched by NOC within SLA window.
+Second Line Maintenance (SLM): Planned or complex corrective work requiring specialist skills (e.g., antenna realignment, HW replacement, BTS software upgrade).
+Battery Discharge Test (BDT) — Separate Workflow or Part of PM?
+Battery Discharge Testing (BDT) is typically structured as a distinct sub-workflow within the annual PM calendar:
+Frequency: Annual or semi-annual (per IEEE 1188 for VRLA batteries, IEEE 450 for flooded lead-acid).
+Test procedure: Disconnect charger; apply constant current load (C/10 or C/20 rate); monitor voltage every 5–10 minutes; terminate when end voltage (1.75Vpc) reached; calculate capacity vs. rated (healthy >80%).
+Data captured: Float voltage (pre-test), discharge current (amps), individual cell voltages (if accessible), temperature, discharge duration, calculated capacity %.
+Workflow: BDT is typically a separate scheduled WO with its own checklist, longer duration (4–8 hours on site), and requires specialist engineer with calibrated load bank equipment.
+BDT finding thresholds: >80% capacity = Pass; 60–80% = Monitor/Warning; <60% = Replace within 3–6 months; <40% = Replace immediately (P1 CM WO generated).
+BDT in Egyptian context: Heat is a major battery degradation factor. Standard 48V VRLA batteries at Egyptian desert sites may degrade 20–30% faster than rated. Many operators increase BDT frequency to semi-annual for desert sites.
+NOTE: Some Egyptian operators have separated BDT into a standalone contract scope item (billed per test, per site), distinct from routine PM visits. This affects workflow design for subcontractor management systems.
+Sources
+ITD Research: What are the different types of telecom maintenance? (EN 13306 reference) — en.it-development.com
+Forum Electrical: Battery Discharge Test Procedure — forumelectrical.com
+Vertiv: VRLA Battery Capacity Testing — vertiv.com
+Exponential Power: VRLA Battery Testing (IEEE-1188) — exponentialpower.com
+DV Power: Discharge Testing on Battery While Online — dv-power.com
+SLM Telecom: Preventive Maintenance / FLM Engineer role description — slm-telecom.com
+GAP: BDT-specific workflows for Egyptian operators not publicly documented. Need primary research on whether BDT is bundled into PM or contracted separately.
+RESEARCH QUESTION 5: OFFLINE / MOBILE OPERATIONS
+No-Coverage Work, Sync Strategy, Conflict Resolution, Platforms
+Industry Standard — Offline-First FSM Architecture
+Modern field service management apps for telecom are built on an offline-first architecture due to the reality of remote BTS sites with no network coverage. Key principles:
+All WO data, checklists, site information, and forms are pre-loaded to the device before the engineer leaves the depot.
+During the visit, all data entry (readings, checklist responses, photos, GPS) is captured to local device storage.
+Photos are stored locally; GPS coordinates are timestamped by device clock (not network time, to prevent spoofing).
+On connectivity restoration (returning to coverage area or connecting to site WiFi), all data is automatically synced to the server.
+Data Synced Offline vs Online
+Available Offline (Pre-loaded)
+Requires Online Sync (Server)
+Work Order details and instructions
+Real-time WO assignment updates from dispatcher
+Site information (coordinates, equipment list)
+New WO creation or cancellation
+PM Checklist forms and validation rules
+Supervisor approval/rejection notifications
+Historical visit data for reference
+Spare parts inventory updates
+GPS capture (device GPS chip, no network needed)
+Photo upload to cloud storage
+Photo capture to local storage
+Live SLA timer updates
+Checklist entry and measurement recording
+Digital signature confirmation
+Conflict Resolution Strategy
+Last-write-wins (LWW): Simplest strategy; server version wins if simultaneous edits detected. Used for status fields.
+Merge strategy: For structured forms, field-by-field merge is applied — only conflicting fields require resolution.
+Timestamp-based: Server compares device timestamp vs. server timestamp; if device submission is earlier (and server has no newer update), device data accepted.
+Supervisor override: On conflict alert, supervisor reviews both versions and selects correct data.
+Key conflict scenarios in telecom PM: Engineer submits WO offline → dispatcher reassigns same WO online. Resolution: WO shows as locked/assigned; reassignment queued until sync.
+Mobile Platforms
+Android: Dominant platform in Egyptian/MENA field service apps due to cost of Android devices and availability of ruggedized Android tablets/phones. Majority of FSM apps target Android first.
+iOS: Used by supervisors and managers; less common for field engineers in Egypt due to cost.
+Global FSM platforms: ServiceNow FSM Mobile (iOS+Android), Salesforce Field Service Lightning (iOS+Android), IFS Field Service Management Mobile (iOS+Android), ClickSoftware (now Salesforce) Mobile.
+Custom apps: Many Egyptian operators and subcontractors use bespoke mobile apps (often built on React Native or Flutter) connected to their FSM backend via REST APIs.
+GPS tracking: Apps typically poll GPS every 30–120 seconds for route tracking; battery-optimized polling for remote sites.
+Sources
+allGeo: Geofencing Technology for Field Service — blog.allgeo.com
+Foresight Mobile: Field Service App Development — foresightmobile.com
+Totalmobile: Field Service Management Software — totalmobile.com
+Zuper: FSM Mobile App — zuper.co/field-service-management-app
+FieldServicely: GPS Time Clock — fieldservicely.com
+GAP: No specific info found on which Android apps Orange Egypt, Vodafone Egypt, or IHS Towers use internally. Vendor RFP documents may specify platform requirements.
+RESEARCH QUESTION 6: APPROVALS & ESCALATIONS
+Review Chain, Roles, Escalation Triggers, Client Portal
+Standard Role Hierarchy in Egyptian Telecom PM Subcontracting
+Role
+Level
+Responsibilities in PM/CM Workflow
+Field Engineer / Technician
+L1 — Subcontractor
+Executes PM/CM visit; completes checklist; takes photos; submits report via mobile app.
+Team Lead / FLM Supervisor
+L2 — Subcontractor
+Reviews field reports for completeness; first-line approval; escalates anomalies; assigns WOs.
+Area Manager
+L3 — Subcontractor
+Regional performance oversight; SLA breach escalation response; manages engineer pool.
+Account Manager
+L4 — Subcontractor / MNO Interface
+Client-facing role; handles KPI reporting; contract compliance; SLA dispute resolution.
+NOC / NMS Operator
+MNO Side
+Creates CM WOs from alarm feeds; monitors real-time SLA; triggers P1 escalations.
+PM Planner
+MNO Side
+Schedules PM visits; generates WOs from maintenance calendar; manages visit windows.
+Client Portal User (MNO)
+MNO Side
+Reviews PM reports; accepts/rejects completed WOs; views SLA dashboards.
+Approval Chain
+Engineer submits PM report (mobile app) → WO status: Pending L2 Review
+FLM Supervisor reviews photos and readings → Approves: WO status: Pending Client Acceptance | Rejects: WO ReOpen with comments
+Client portal notified → MNO reviewer accepts or rejects
+On acceptance: WO Closed; KPIs updated; invoice trigger
+On rejection: Subcontractor alerted; may require re-visit or additional evidence
+Escalation Triggers
+SLA At-Risk: 75% of SLA window elapsed → Automated alert to supervisor and area manager.
+SLA Breach: 100% of SLA window elapsed → Alert to account manager and client; penalty calculation begins.
+P1 WO not responded within 1 hour → Auto-escalation to NOC Manager and CTO on-call.
+3+ consecutive PM visit rejections by client → Escalated to account manager; potential SLA audit.
+GPS anomaly detected → Alert to supervisor for manual review.
+Client Portal
+Best-practice FSM implementations provide MNO clients with a read-only portal offering:
+Real-time WO status dashboard (by region, by site, by priority)
+SLA compliance heatmap (green/amber/red per site cluster)
+Evidence package viewer (photos, measurements, GPS tracks per visit)
+Monthly KPI report download (PDF/Excel)
+Accept/Reject workflow for completed WOs
+Escalation submission for critical issues
+NOTE: In Egypt, client portals are not universally deployed. Some operators still use email-based evidence submission (PDF reports + photo ZIP attachments) and manual approval via email sign-off. This is a significant gap vs. global best practice.
+Sources
+Vodafone Egypt job descriptions referencing subcontractor SLA KPI management — via LinkedIn/Flexa
+SLM Telecom: FLM Engineer role description — slm-telecom.com
+SAP PM Flexible Workflow for approval chain — SAP Community blogs
+Ericsson Managed Network Services: NOC-driven field operations — ericsson.com
+GAP: No public org charts or approval workflow documents available for Egyptian operators. Subcontractor management contracts not publicly available.
+RESEARCH QUESTION 7: REPORTING & KPIs
+Standard KPIs, Contractor Scorecard, Standard Reports
+Standard KPIs in Egyptian Telecom PM
+KPI
+Definition
+Target
+Freq
+First-Time-Fix Rate (FTF/FTFR)
+% of WOs resolved on first field visit without rework
+>85%
+Monthly
+MTTR
+Mean Time to Repair — avg hours from fault creation to restoration
+<4 hrs (P1)
+Monthly
+SLA Compliance %
+% of WOs resolved within contracted SLA window
+>95%
+Monthly
+PM Visit Completion Rate
+% of scheduled PM visits completed within the month
+>98%
+Monthly
+Evidence Completeness Score
+% of submitted WOs with complete evidence package (photos, readings, GPS)
+>95%
+Weekly
+Network Availability / Uptime
+% time sites are operational; tracked by NMS. 'Five nines' = 99.999%
+>99.7%
+Real-time
+SLA Breach Count
+Number of WOs where SLA was breached in period
+0 (P1/P2)
+Weekly
+Rejection Rate
+% of submitted WOs rejected by supervisor or client
+<5%
+Monthly
+MTBF
+Mean Time Between Failures — avg operational time between faults per site
+>90 days
+Quarterly
+Battery Health Score
+% of batteries with capacity >80% (from BDT results)
+>90%
+Semi-annual
+Engineer Utilization Rate
+% of available working hours allocated to productive WO work
+>75%
+Monthly
+Contractor Scorecard Generation
+A subcontractor performance scorecard in the Egyptian telecom context typically covers:
+Monthly SLA compliance per priority class (P1, P2, P3, P4) — weighted score
+PM visit completion vs. schedule (% on-time)
+Evidence quality score (auto-scored + supervisor-scored)
+FTF rate per region / per engineer
+Average MTTR per month vs. contractual target
+Number of SLA breaches (with penalty calculation)
+Compliance audit findings (GPS anomalies, after-hours visits)
+Scorecard is typically generated as a monthly PDF and Excel report, signed off by both subcontractor account manager and MNO PM Manager. It feeds into quarterly performance reviews and contract renewal decisions.
+Standard Report Deliverables
+Daily NOC Status Report: Active P1/P2 incidents, open WOs, site downtime log.
+Weekly PM Completion Report: Sites visited vs. scheduled; overdue PMs; exceptions.
+Monthly SLA Compliance Report: KPI summary table, breach details, trend charts.
+Monthly Contractor Scorecard: Full performance matrix vs. contractual targets.
+Quarterly Battery Health Report: BDT results by site; replacement recommendations.
+Annual Network Reliability Report: MTBF, MTTR trends; failure mode analysis.
+Sources
+NetSuite: 23 Critical Telecom KPIs — netsuite.com
+PTC: Most Important KPIs in Field Service Management — ptc.com
+Atlassian: Incident Management KPIs — atlassian.com
+BSC Designer: Enhancing KPI Governance Through SLA Scorecards in Telecom — bscdesigner.com
+European Journal of Innovative Studies: MTBF, MTTR, SLA study at Nigerian telecom — ejiss.com
+GAP: Egyptian-specific KPI targets are not publicly available. Operator SLA contracts are confidential. The targets listed above are industry estimates based on global benchmarks.
+RESEARCH QUESTION 8: INTEGRATION POINTS
+OSS/BSS, APIs, SCADA/NMS to WO Creation
+Standard Integration Architecture
+A telecom PM/CM FSM system integrates with multiple surrounding systems in the operator's technical stack:
+System
+Integration Direction
+Data Exchanged
+NMS / OSS (e.g., Huawei U2000, Ericsson OSS-RC)
+NMS → FSM (alarm push)
+Alarm ID, site ID, severity, alarm time, alarm description → triggers CM WO creation automatically.
+SCADA / Remote Monitoring (e.g., Galooli, Huawei iManager)
+SCADA → FSM (event push)
+Power alarms (generator start, battery low, AC fail), environmental sensors (temp, smoke, flood) → PM/CM triggers.
+GIS / Site Database
+GIS → FSM (lookup)
+Site coordinates, equipment inventory, site photos, access instructions, tower type → pre-loaded to engineer's mobile app.
+ERP / Finance (SAP, Oracle)
+FSM → ERP (WO close trigger)
+WO completion triggers: labor cost posting, material consumption, service invoice creation, contract milestones.
+HR / Workforce Management
+HR → FSM (resource data)
+Engineer availability, skills, certifications, leave schedules → used for optimal dispatch assignment.
+Inventory / Spare Parts
+FSM ↔ Inventory (bidirectional)
+WO requests spare parts → inventory reserved; engineer confirms consumption → inventory updated.
+Client Portal (MNO)
+FSM → Portal (push)
+Real-time WO status, SLA dashboards, evidence packages, monthly KPI reports.
+API and Data Formats
+REST APIs: Primary integration method for modern FSM systems (ServiceNow, Salesforce FSM, custom platforms). JSON payload format.
+SOAP/XML: Older OSS systems (e.g., some Huawei NMS versions) may use SOAP web services for alarm integration.
+Kafka/Message Queue: For high-volume alarm streams from NMS to FSM; event-driven architecture.
+CSV/Excel Import: Used for bulk site data import (site database, equipment inventory) during initial system setup.
+SFTP/FTP: Batch transfer of reports, evidence packages (photo ZIPs) to client systems.
+TM Forum APIs (Open APIs): Industry standard for telecom OSS/BSS integration; TMF660 (Resource Trouble Management API) is relevant for CM WO creation from NMS alarms.
+SCADA/NMS → Work Order Creation Flow
+NMS detects alarm on BTS site (e.g., 'Battery Low Voltage', VSWR alarm, AC power failure)
+Alarm severity classified (mapped to P1/P2/P3 based on alarm type and site criticality)
+If threshold met: NMS pushes alarm to FSM via API webhook or Kafka topic
+FSM auto-creates CM work order: populates site ID, alarm details, priority, SLA clock started
+WO is assigned to NOC queue → NOC verifies and assigns to nearest available engineer
+Engineer notified via mobile app push notification; WO moves to Assigned status
+NOTE: Not all Egyptian operators have achieved full NMS→FSM automation. Many still rely on manual NOC-to-dispatcher phone calls for WO creation, especially for smaller subcontractors.
+Sources
+Ericsson Operations Engine / NOC operations model — ericsson.com
+Ericsson Service Orchestration and Assurance — ericsson.com
+TM Forum Open API TMF660 Resource Trouble Management — tmforum.org
+Galooli Tower Remote Monitoring — galooli.com
+IBM Maximo: Work Order creation triggers (condition monitoring, escalation, external systems) — maximosecrets.com
+GAP: Specific NMS/OSS integration architectures for Orange Egypt and Vodafone Egypt not publicly documented. NMS vendor (Huawei/Ericsson/Nokia) determines available alarm API formats.
+COMPARATIVE MATRIX
+Orange Egypt | Vodafone Egypt | IHS Towers | IBM Maximo | SAP PM
+NOTE: Matrix values marked * are based on industry inference from job descriptions, general market knowledge, and analogous operators. Company-specific primary research is required to validate.
+Dimension
+Orange Egypt*
+Vodafone Egypt*
+IHS Towers Egypt*
+IBM Maximo
+SAP PM (S/4)
+WO States
+~6 states (New, Assigned, InProgress, PendingReview, Closed, ReOpen)
+~6-7 states; likely similar to Orange; SLA-driven
+Custom FSM; PowerNOC or similar; energy-focused states
+WAPPR→APPR→WSCH→INPRG→WMATL→COMP→CLOSE + synonyms (11 states)
+9-phase model: Create→Evaluate→Plan→Approve→Release→Execute→TECO→Close
+SLA Classes
+P1/P2/P3/P4; P1=2-4hr restore*; aligned to NTRA requirements
+P1/P2/P3/P4; similar structure; 24/7 NOC for P1/P2*
+Energy SLA (uptime %); structural SLA separate; PaaS model
+SLA managed via escalation module; configurable time-based triggers
+SLA via SAP QM or custom apps; not native PM module strength
+Visit Types
+PM (monthly/quarterly/annual), CM/FLM (reactive), BDT (semi-annual), SLM (specialist)*
+PM, FLM, SLM, BDT; likely similar to Orange*
+PM (energy/structural), CM (power), BDT, Generator PM, Structural inspection
+PM (time/meter/condition-based), CM, Inspection; all as separate WO types
+PM01 (Preventive), PM02 (Corrective), PM03 (Inspection) order types recommended
+Approval Chain
+Engineer → FLM Supervisor → PM Manager → Client Portal (Orange side)*
+Engineer → Team Lead → Supervisor → Client (Vodafone side)*
+Engineer → Site Manager → IHS NOC → MNO Client (tenant)*
+Configurable via Workflow Designer; up to N-tier; supports role-based routing
+Flexible Workflow: supports multi-step; condition-based; team or individual approvers
+Mobile Support
+Android mobile app (custom or Ericsson Microsite tool)*; offline capable*
+Android-first mobile app; likely _VOIS-managed BPO platform*
+IHS Connect app or custom Android app for field teams*
+Maximo Mobile (iOS+Android); Maximo Anywhere; role-based apps; offline-capable
+SAP Work Manager / SAP Fiori Apps (iOS+Android); offline via SAP Offline OData
+KPIs
+FTF, MTTR, SLA compliance %, PM completion rate, network availability*
+FTF, MTTR, SLA compliance %, rejection rate, evidence completeness*
+Site uptime %, energy efficiency, generator runtime, fuel cost, battery health*
+KPI reporting via Maximo Reports/Cognos; configurable dashboards; MTTR, PM compliance, WO backlog
+KPIs via SAP Analytics Cloud; standard PM reports: IW38, IW39, IH08; PM compliance dashboards
+OSS/NMS Integration
+Huawei/Ericsson NMS alarm → manual NOC dispatch*; partial automation*
+NMS alarm → NOC → FLM dispatch; possibly more automated via _VOIS*
+Proprietary NOC system; remote monitoring for energy (solar, battery, fuel)*
+SCADA/NMS integration via Maximo Integration Framework (MIF); REST/SOAP adapters
+Integration via SAP PI/PO or SAP Integration Suite; standard NMS alarm adapters available
+RECOMMENDATIONS
+Best Practice Workflow Design for Egyptian Telecom PM System — Subcontractor Management Focus
+1. Work Order State Machine Design
+Implement a 7-state model: New → Assigned → InProgress → PendingL2Review → PendingClientAcceptance → Closed | ReOpen.
+Add a separate Emergency/Reactive WO type (CM/BM) with auto-generated SLA clock from creation timestamp.
+ReOpen must require mandatory rejection reason (categorized: Missing Photos, GPS Mismatch, Incorrect Readings, Incomplete Checklist, Client Rejection).
+Consider a Deferred state for PM visits rescheduled due to site access restrictions (guard approval, safety issue).
+2. Priority & SLA Configuration
+Implement P1–P4 priority matrix with configurable response/resolution windows per site class (Urban, Rural, Desert).
+At-Risk alerts at 70% of SLA window elapsed (not 80% — gives more time for remote sites).
+SLA clock pause conditions: Site access denied (with evidence), sandstorm/extreme weather, spare parts ordered (with PO reference).
+Separate SLA metrics for PM visits (completion vs. schedule) vs. CM visits (response and resolution times).
+3. Visit Checklist Architecture
+Design modular checklists: Core BTS checklist + Power Module + Generator Module + MW Module + Structural Module (enabled per site type).
+Mandatory fields enforcement: System must block WO submission until all mandatory fields are completed.
+Measurement range validation: Flag out-of-range readings for supervisor attention (not hard-block, but prominent warning).
+Photo requirements: Minimum 15 photos per standard BTS PM; 25+ for generator sites. Auto-categorize photo types.
+BDT workflow: Implement as a separate WO type with dedicated checklist, 4–8hr expected duration, and specific discharge data fields (V, A, time, temp, capacity%).
+4. Offline-First Mobile Architecture
+Build Android-first with iOS secondary. Target Android 10+ for compatibility with Egyptian field device fleet.
+Pre-load WOs for 7-day rolling window to device on morning sync.
+GPS capture every check-in/check-out; photos auto-tagged with GPS+timestamp.
+Configurable geofence radius per site (50m urban, 200m rural, 500m desert).
+If engineer is outside geofence: Allow override with mandatory supervisor notification and photo evidence of engineer being at site.
+Sync strategy: Timestamp-based; auto-sync on connectivity; conflict alert to supervisor for manual resolution.
+5. Approval Chain and Client Portal
+Mandatory L2 (FLM Supervisor) review before any WO reaches Closed status.
+Client portal: Provide MNO clients with real-time dashboards (WO status by region, SLA heatmap, evidence viewer).
+Digital signature: Implement engineer digital signature at check-out; supervisor digital approval on review.
+Escalation: Automated SLA breach alerts via SMS + in-app notification to area manager and account manager.
+6. Subcontractor KPI Scorecard
+Auto-generate monthly scorecard: FTF rate, SLA compliance % by priority class, PM completion %, rejection rate, MTTR.
+Engineer-level drilldown: Show individual engineer performance; identify training needs.
+Financial linkage: SLA breach penalties automatically calculated and reflected in payment deductions.
+Benchmark comparison: Compare subcontractor performance across regions; enable competitive accountability.
+7. Integration Strategy
+Phase 1: REST API for NMS alarm → auto CM WO creation. Start with highest-volume alarm types.
+Phase 2: GIS/site database integration for auto-population of site data in WOs.
+Phase 3: ERP integration for WO close → invoice creation → payment trigger.
+Use TM Forum TMF660 Resource Trouble Management API as standard for NMS integration.
+Provide CSV/Excel bulk import for initial site database population.
+8. Egyptian Market Adaptations
+Arabic language support: Full bilingual UI (Arabic + English) is essential for field engineers.
+Ramadan scheduling: PM calendar must support Ramadan-adjusted working hours (shorter days).
+Khamsin/dust storm SLA pause: Implement seasonal force majeure clauses in SLA engine.
+Upper Egypt remote sites: Extended offline capability (72hr without sync) and larger geofence radii.
+Diesel generator prevalence: Generator PM and fuel tracking workflows are more critical than in European markets.
+BDT frequency increase: Default semi-annual BDT for desert sites due to heat-accelerated battery degradation.
+END OF REPORT  |  February 2026  |  For internal use — further primary research recommended for Egyptian operator specifics

--- a/src/TelecomPM.Domain/Interfaces/Repositories/IWorkOrderRepository.cs
+++ b/src/TelecomPM.Domain/Interfaces/Repositories/IWorkOrderRepository.cs
@@ -6,6 +6,9 @@ using TelecomPM.Domain.Enums;
 public interface IWorkOrderRepository : IRepository<WorkOrder, Guid>
 {
     Task<WorkOrder?> GetByWoNumberAsync(string woNumber, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<WorkOrder>> GetOpenForSlaEvaluationAsync(
+        int take,
+        CancellationToken cancellationToken = default);
     Task<int> CountClosedAsync(
         string? officeCode,
         SlaClass? slaClass,

--- a/src/TelecomPm.Api/Controllers/ClientPortalController.cs
+++ b/src/TelecomPm.Api/Controllers/ClientPortalController.cs
@@ -72,6 +72,13 @@ public sealed class ClientPortalController : ApiControllerBase
         return HandleResult(result);
     }
 
+    [HttpGet("visits/{visitId:guid}/evidence")]
+    public async Task<IActionResult> GetVisitEvidence(Guid visitId, CancellationToken cancellationToken)
+    {
+        var result = await Mediator.Send(visitId.ToPortalVisitEvidenceQuery(), cancellationToken);
+        return HandleResult(result);
+    }
+
     [HttpPatch("workorders/{id:guid}/accept")]
     public async Task<IActionResult> AcceptWorkOrder(Guid id, CancellationToken cancellationToken)
     {

--- a/src/TelecomPm.Api/Mappings/PortalContractMapper.cs
+++ b/src/TelecomPm.Api/Mappings/PortalContractMapper.cs
@@ -1,4 +1,5 @@
 using TelecomPM.Application.Queries.Portal.GetPortalDashboard;
+using TelecomPM.Application.Queries.Portal.GetPortalVisitEvidence;
 using TelecomPM.Application.Queries.Portal.GetPortalSites;
 using TelecomPM.Application.Queries.Portal.GetPortalSlaReport;
 using TelecomPM.Application.Queries.Portal.GetPortalVisits;
@@ -25,4 +26,7 @@ public static class PortalContractMapper
 
     public static GetPortalVisitsQuery ToPortalVisitsQuery(this string siteCode, int pageNumber, int pageSize)
         => new() { SiteCode = siteCode, PageNumber = pageNumber, PageSize = pageSize };
+
+    public static GetPortalVisitEvidenceQuery ToPortalVisitEvidenceQuery(this Guid visitId)
+        => new() { VisitId = visitId };
 }

--- a/src/TelecomPm.Application/Common/Interfaces/IPortalReadRepository.cs
+++ b/src/TelecomPm.Application/Common/Interfaces/IPortalReadRepository.cs
@@ -27,5 +27,10 @@ public interface IPortalReadRepository
         bool anonymizeEngineers,
         CancellationToken cancellationToken = default);
 
+    Task<PortalVisitEvidenceDto?> GetVisitEvidenceAsync(
+        string clientCode,
+        Guid visitId,
+        CancellationToken cancellationToken = default);
+
     Task<PortalSlaReportDto> GetSlaReportAsync(string clientCode, CancellationToken cancellationToken = default);
 }

--- a/src/TelecomPm.Application/DTOs/Portal/PortalVisitEvidenceDto.cs
+++ b/src/TelecomPm.Application/DTOs/Portal/PortalVisitEvidenceDto.cs
@@ -1,0 +1,47 @@
+using TelecomPM.Domain.Enums;
+
+namespace TelecomPM.Application.DTOs.Portal;
+
+public sealed class PortalVisitEvidenceDto
+{
+    public Guid VisitId { get; init; }
+    public string VisitNumber { get; init; } = string.Empty;
+    public string SiteCode { get; init; } = string.Empty;
+    public VisitType VisitType { get; init; }
+    public VisitStatus VisitStatus { get; init; }
+    public DateTime ScheduledDateUtc { get; init; }
+    public IReadOnlyList<PortalVisitPhotoEvidenceDto> Photos { get; init; } = Array.Empty<PortalVisitPhotoEvidenceDto>();
+    public IReadOnlyList<PortalVisitReadingEvidenceDto> Readings { get; init; } = Array.Empty<PortalVisitReadingEvidenceDto>();
+    public IReadOnlyList<PortalVisitChecklistEvidenceDto> ChecklistItems { get; init; } = Array.Empty<PortalVisitChecklistEvidenceDto>();
+}
+
+public sealed class PortalVisitPhotoEvidenceDto
+{
+    public Guid PhotoId { get; init; }
+    public PhotoType Type { get; init; }
+    public PhotoCategory Category { get; init; }
+    public string ItemName { get; init; } = string.Empty;
+    public string FileName { get; init; } = string.Empty;
+    public DateTime? CapturedAtUtc { get; init; }
+}
+
+public sealed class PortalVisitReadingEvidenceDto
+{
+    public Guid ReadingId { get; init; }
+    public string ReadingType { get; init; } = string.Empty;
+    public string Category { get; init; } = string.Empty;
+    public decimal Value { get; init; }
+    public string Unit { get; init; } = string.Empty;
+    public bool IsWithinRange { get; init; }
+    public DateTime MeasuredAtUtc { get; init; }
+}
+
+public sealed class PortalVisitChecklistEvidenceDto
+{
+    public Guid ChecklistItemId { get; init; }
+    public string Category { get; init; } = string.Empty;
+    public string ItemName { get; init; } = string.Empty;
+    public CheckStatus Status { get; init; }
+    public bool IsMandatory { get; init; }
+    public DateTime? CompletedAtUtc { get; init; }
+}

--- a/src/TelecomPm.Application/Queries/Portal/GetPortalVisitEvidence/GetPortalVisitEvidenceQuery.cs
+++ b/src/TelecomPm.Application/Queries/Portal/GetPortalVisitEvidence/GetPortalVisitEvidenceQuery.cs
@@ -1,0 +1,10 @@
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.DTOs.Portal;
+
+namespace TelecomPM.Application.Queries.Portal.GetPortalVisitEvidence;
+
+public sealed class GetPortalVisitEvidenceQuery : IRequest<Result<PortalVisitEvidenceDto>>
+{
+    public Guid VisitId { get; init; }
+}

--- a/src/TelecomPm.Application/Queries/Portal/GetPortalVisitEvidence/GetPortalVisitEvidenceQueryHandler.cs
+++ b/src/TelecomPm.Application/Queries/Portal/GetPortalVisitEvidence/GetPortalVisitEvidenceQueryHandler.cs
@@ -1,0 +1,44 @@
+using MediatR;
+using TelecomPM.Application.Common;
+using TelecomPM.Application.Common.Interfaces;
+using TelecomPM.Application.DTOs.Portal;
+using TelecomPM.Domain.Interfaces.Repositories;
+
+namespace TelecomPM.Application.Queries.Portal.GetPortalVisitEvidence;
+
+public sealed class GetPortalVisitEvidenceQueryHandler : IRequestHandler<GetPortalVisitEvidenceQuery, Result<PortalVisitEvidenceDto>>
+{
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IUserRepository _userRepository;
+    private readonly IPortalReadRepository _portalReadRepository;
+
+    public GetPortalVisitEvidenceQueryHandler(
+        ICurrentUserService currentUserService,
+        IUserRepository userRepository,
+        IPortalReadRepository portalReadRepository)
+    {
+        _currentUserService = currentUserService;
+        _userRepository = userRepository;
+        _portalReadRepository = portalReadRepository;
+    }
+
+    public async Task<Result<PortalVisitEvidenceDto>> Handle(GetPortalVisitEvidenceQuery request, CancellationToken cancellationToken)
+    {
+        if (request.VisitId == Guid.Empty)
+            return Result.Failure<PortalVisitEvidenceDto>("VisitId is required.");
+
+        var portalUser = await _userRepository.GetByIdAsNoTrackingAsync(_currentUserService.UserId, cancellationToken);
+        if (portalUser is null || !portalUser.IsClientPortalUser || string.IsNullOrWhiteSpace(portalUser.ClientCode))
+            return Result.Failure<PortalVisitEvidenceDto>("Portal access is not enabled for this user.");
+
+        var evidence = await _portalReadRepository.GetVisitEvidenceAsync(
+            portalUser.ClientCode,
+            request.VisitId,
+            cancellationToken);
+
+        if (evidence is null)
+            return Result.Failure<PortalVisitEvidenceDto>("Visit not found.");
+
+        return Result.Success(evidence);
+    }
+}

--- a/src/TelecomPm.Infrastructure/DependencyInjection.cs
+++ b/src/TelecomPm.Infrastructure/DependencyInjection.cs
@@ -99,12 +99,14 @@ public static class DependencyInjection
         services.AddScoped<ISettingsEncryptionService, SettingsEncryptionService>();
         services.AddScoped<ISystemSettingsService, SystemSettingsService>();
         services.AddScoped<IOtpService, OtpService>();
+        services.AddScoped<SlaEvaluationProcessor>();
 
         // Domain Services with Infrastructure dependencies (Repository-dependent)
         services.AddScoped<IVisitNumberGeneratorService, VisitNumberGeneratorService>();
         services.AddScoped<IMaterialStockService, MaterialStockService>();
         services.AddScoped<ISlaClockService, SlaClockService>();
         services.AddScoped<IGeoCheckInService, GeoCheckInService>();
+        services.AddHostedService<SlaEvaluationHostedService>();
 
         // HttpContextAccessor for CurrentUserService
         services.AddHttpContextAccessor();

--- a/src/TelecomPm.Infrastructure/Persistence/SeedData/DatabaseSeeder.cs
+++ b/src/TelecomPm.Infrastructure/Persistence/SeedData/DatabaseSeeder.cs
@@ -436,6 +436,9 @@ public class DatabaseSeeder
             CreateSetting("SLA:P3:ResponseMinutes", "1440", "SLA", "int", "Response deadline for P3 in minutes", false, seededBy),
             CreateSetting("SLA:P4:ResponseMinutes", "2880", "SLA", "int", "Response deadline for P4 in minutes", false, seededBy),
             CreateSetting("SLA:AtRiskThresholdPercent", "70", "SLA", "int", "At-risk threshold as percent of response window elapsed", false, seededBy),
+            CreateSetting("SLA:Evaluation:Enabled", "true", "SLA", "bool", "Enable background SLA status evaluation", false, seededBy),
+            CreateSetting("SLA:Evaluation:IntervalSeconds", "60", "SLA", "int", "SLA evaluation polling interval in seconds", false, seededBy),
+            CreateSetting("SLA:Evaluation:BatchSize", "200", "SLA", "int", "Number of open work orders evaluated per cycle", false, seededBy),
 
             // Evidence
             CreateSetting("Evidence:BM:MinPhotos", "3", "Evidence", "int", "Minimum BM photos", false, seededBy),

--- a/src/TelecomPm.Infrastructure/Services/SlaEvaluationHostedService.cs
+++ b/src/TelecomPm.Infrastructure/Services/SlaEvaluationHostedService.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TelecomPM.Application.Common.Interfaces;
+
+namespace TelecomPM.Infrastructure.Services;
+
+public sealed class SlaEvaluationHostedService : BackgroundService
+{
+    private const int DefaultIntervalSeconds = 60;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<SlaEvaluationHostedService> _logger;
+
+    public SlaEvaluationHostedService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<SlaEvaluationHostedService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("SLA evaluation hosted service started.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var interval = TimeSpan.FromSeconds(DefaultIntervalSeconds);
+
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var settings = scope.ServiceProvider.GetRequiredService<ISystemSettingsService>();
+                var processor = scope.ServiceProvider.GetRequiredService<SlaEvaluationProcessor>();
+
+                var isEnabled = await settings.GetAsync(
+                    "SLA:Evaluation:Enabled",
+                    true,
+                    stoppingToken);
+
+                var configuredIntervalSeconds = await settings.GetAsync(
+                    "SLA:Evaluation:IntervalSeconds",
+                    DefaultIntervalSeconds,
+                    stoppingToken);
+
+                interval = TimeSpan.FromSeconds(Math.Clamp(configuredIntervalSeconds, 15, 3600));
+
+                if (isEnabled)
+                {
+                    var processedCount = await processor.EvaluateBatchAsync(stoppingToken);
+                    _logger.LogDebug("SLA evaluation cycle completed. Processed={ProcessedCount}", processedCount);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "SLA evaluation cycle failed.");
+            }
+
+            try
+            {
+                await Task.Delay(interval, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+
+        _logger.LogInformation("SLA evaluation hosted service stopped.");
+    }
+}

--- a/src/TelecomPm.Infrastructure/Services/SlaEvaluationProcessor.cs
+++ b/src/TelecomPm.Infrastructure/Services/SlaEvaluationProcessor.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+using TelecomPM.Application.Common.Interfaces;
+using TelecomPM.Domain.Interfaces.Repositories;
+using TelecomPM.Domain.Services;
+
+namespace TelecomPM.Infrastructure.Services;
+
+public sealed class SlaEvaluationProcessor
+{
+    private const int DefaultBatchSize = 200;
+    private readonly IWorkOrderRepository _workOrderRepository;
+    private readonly ISlaClockService _slaClockService;
+    private readonly ISystemSettingsService _settingsService;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<SlaEvaluationProcessor> _logger;
+
+    public SlaEvaluationProcessor(
+        IWorkOrderRepository workOrderRepository,
+        ISlaClockService slaClockService,
+        ISystemSettingsService settingsService,
+        IUnitOfWork unitOfWork,
+        ILogger<SlaEvaluationProcessor> logger)
+    {
+        _workOrderRepository = workOrderRepository;
+        _slaClockService = slaClockService;
+        _settingsService = settingsService;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<int> EvaluateBatchAsync(CancellationToken cancellationToken = default)
+    {
+        var configuredBatchSize = await _settingsService.GetAsync(
+            "SLA:Evaluation:BatchSize",
+            DefaultBatchSize,
+            cancellationToken);
+
+        var batchSize = Math.Clamp(configuredBatchSize, 1, 2_000);
+        var workOrders = await _workOrderRepository.GetOpenForSlaEvaluationAsync(batchSize, cancellationToken);
+        if (workOrders.Count == 0)
+            return 0;
+
+        foreach (var workOrder in workOrders)
+        {
+            await _slaClockService.EvaluateStatusAsync(workOrder, cancellationToken);
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        _logger.LogDebug(
+            "SLA evaluation processed {Count} open work orders in one batch.",
+            workOrders.Count);
+
+        return workOrders.Count;
+    }
+}

--- a/tests/TelecomPM.Infrastructure.Tests/Services/SlaEvaluationProcessorTests.cs
+++ b/tests/TelecomPM.Infrastructure.Tests/Services/SlaEvaluationProcessorTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TelecomPM.Application.Common.Interfaces;
+using TelecomPM.Domain.Entities.WorkOrders;
+using TelecomPM.Domain.Enums;
+using TelecomPM.Domain.Interfaces.Repositories;
+using TelecomPM.Domain.Services;
+using TelecomPM.Infrastructure.Services;
+using Xunit;
+
+namespace TelecomPM.Infrastructure.Tests.Services;
+
+public class SlaEvaluationProcessorTests
+{
+    [Fact]
+    public async Task EvaluateBatchAsync_ShouldEvaluateOpenWorkOrders_AndPersistChanges()
+    {
+        var workOrder1 = WorkOrder.Create("WO-SLA-EVAL-1", "CAI001", "CAI", SlaClass.P1, "Issue");
+        var workOrder2 = WorkOrder.Create("WO-SLA-EVAL-2", "CAI002", "CAI", SlaClass.P2, "Issue");
+
+        var workOrderRepository = new Mock<IWorkOrderRepository>();
+        workOrderRepository
+            .Setup(r => r.GetOpenForSlaEvaluationAsync(2, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<WorkOrder> { workOrder1, workOrder2 });
+
+        var slaClockService = new Mock<ISlaClockService>();
+        slaClockService
+            .Setup(s => s.EvaluateStatusAsync(It.IsAny<WorkOrder>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SlaStatus.OnTime);
+
+        var settingsService = new Mock<ISystemSettingsService>();
+        settingsService
+            .Setup(s => s.GetAsync("SLA:Evaluation:BatchSize", 200, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+
+        var sut = new SlaEvaluationProcessor(
+            workOrderRepository.Object,
+            slaClockService.Object,
+            settingsService.Object,
+            unitOfWork.Object,
+            Mock.Of<ILogger<SlaEvaluationProcessor>>());
+
+        var processed = await sut.EvaluateBatchAsync(CancellationToken.None);
+
+        processed.Should().Be(2);
+        slaClockService.Verify(s => s.EvaluateStatusAsync(workOrder1, It.IsAny<CancellationToken>()), Times.Once);
+        slaClockService.Verify(s => s.EvaluateStatusAsync(workOrder2, It.IsAny<CancellationToken>()), Times.Once);
+        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateBatchAsync_ShouldSkipPersistence_WhenNoOpenWorkOrders()
+    {
+        var workOrderRepository = new Mock<IWorkOrderRepository>();
+        workOrderRepository
+            .Setup(r => r.GetOpenForSlaEvaluationAsync(200, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<WorkOrder>());
+
+        var settingsService = new Mock<ISystemSettingsService>();
+        settingsService
+            .Setup(s => s.GetAsync("SLA:Evaluation:BatchSize", 200, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(200);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+
+        var sut = new SlaEvaluationProcessor(
+            workOrderRepository.Object,
+            Mock.Of<ISlaClockService>(),
+            settingsService.Object,
+            unitOfWork.Object,
+            Mock.Of<ILogger<SlaEvaluationProcessor>>());
+
+        var processed = await sut.EvaluateBatchAsync(CancellationToken.None);
+
+        processed.Should().Be(0);
+        unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}


### PR DESCRIPTION
Implemented the critical gaps I could verify from the current codebase and your latest findings.

What I changed

KPI reopen-rate mismatch fixed
CountClosedWithReopenedHistoryAsync now counts only true reopened history (not Rework):
[WorkOrderRepository.cs (line 66)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Checklist template applicability enforced at visit start
StartVisit now filters template items by ApplicableSiteTypes and ApplicableVisitTypes (supports aliases like GF, RT, BM, CM, All, JSON arrays):
[StartVisitCommandHandler.cs (line 74)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[StartVisitCommandHandler.cs (line 157)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
SLA engine actually wired into runtime
Added open-work-order batch retrieval:
[IWorkOrderRepository.cs (line 9)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[WorkOrderRepository.cs (line 19)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Added SLA evaluation processor + hosted background service:
[SlaEvaluationProcessor.cs (line 8)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[SlaEvaluationHostedService.cs (line 8)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Registered in DI:
[DependencyInjection.cs (line 102)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[DependencyInjection.cs (line 109)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Seeded control settings:
[DatabaseSeeder.cs (line 439)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Portal evidence package viewer added (client-scoped)
New read model + repository method + query handler + endpoint:
[PortalVisitEvidenceDto.cs (line 1)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[IPortalReadRepository.cs (line 30)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[PortalReadRepository.cs (line 239)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[GetPortalVisitEvidenceQueryHandler.cs (line 9)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[ClientPortalController.cs (line 75)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[PortalContractMapper.cs (line 30)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
API doc updated:
[Api-Doc.md](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Tests added/updated

[StartVisitCommandHandlerTests.cs (line 230)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[PortalQueriesTests.cs (line 140)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[SlaEvaluationProcessorTests.cs (line 17)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Validation run

[dotnet build TelecomPM.sln](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#) passed
[dotnet test TelecomPM.sln](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#) passed
Domain: 137 passed
Application: 155 passed
Infrastructure: 27 passed
[check_doc_drift.py](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#) passedImplemented the critical gaps I could verify from the current codebase and your latest findings.

What I changed

KPI reopen-rate mismatch fixed
CountClosedWithReopenedHistoryAsync now counts only true reopened history (not Rework):
[WorkOrderRepository.cs (line 66)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Checklist template applicability enforced at visit start
StartVisit now filters template items by ApplicableSiteTypes and ApplicableVisitTypes (supports aliases like GF, RT, BM, CM, All, JSON arrays):
[StartVisitCommandHandler.cs (line 74)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[StartVisitCommandHandler.cs (line 157)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
SLA engine actually wired into runtime
Added open-work-order batch retrieval:
[IWorkOrderRepository.cs (line 9)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[WorkOrderRepository.cs (line 19)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Added SLA evaluation processor + hosted background service:
[SlaEvaluationProcessor.cs (line 8)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[SlaEvaluationHostedService.cs (line 8)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Registered in DI:
[DependencyInjection.cs (line 102)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[DependencyInjection.cs (line 109)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Seeded control settings:
[DatabaseSeeder.cs (line 439)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Portal evidence package viewer added (client-scoped)
New read model + repository method + query handler + endpoint:
[PortalVisitEvidenceDto.cs (line 1)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[IPortalReadRepository.cs (line 30)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[PortalReadRepository.cs (line 239)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[GetPortalVisitEvidenceQueryHandler.cs (line 9)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[ClientPortalController.cs (line 75)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[PortalContractMapper.cs (line 30)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
API doc updated:
[Api-Doc.md](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Tests added/updated

[StartVisitCommandHandlerTests.cs (line 230)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[PortalQueriesTests.cs (line 140)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
[SlaEvaluationProcessorTests.cs (line 17)](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#)
Validation run

[dotnet build TelecomPM.sln](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#) passed
[dotnet test TelecomPM.sln](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#) passed
Domain: 137 passed
Application: 155 passed
Infrastructure: 27 passed
[check_doc_drift.py](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/Boo/.vscode/extensions/openai.chatgpt-0.4.76-win32-x64/webview/#) passed