### PR TITLE
docs: sync BC-06 implementation status after merge

### DIFF
--- a/docs/Backend-Auto-Discovery-Report.md
+++ b/docs/Backend-Auto-Discovery-Report.md
@@ -192,7 +192,7 @@ Reference files:
 Source of truth:
 - `docs/Business-Confirmation-Checklist.md`
 
-### 3.1 Confirmed decisions (approved policy, implementation pending/partial)
+### 3.1 Confirmed decisions (approved policy)
 1. BC-01 Session policy (`#47`)
    - Access token TTL 15 minutes.
    - Refresh token TTL 7 days, rotating per use.
@@ -213,13 +213,13 @@ Source of truth:
    - Standard response: `{ data, pagination }`.
    - `sortBy` must be server allowlist-validated.
 
-### 3.2 Business clarification still required
+### 3.2 Implementation status for approved decisions
 1. BC-05 Data retention and privacy (`#51`)
-   - photos, signatures, audit logs, export data retention windows and deletion/export policy.
+   - Approved, implementation pending in tracking issue `#62`.
 2. BC-06 Upload security policy (`#52`)
-   - malware scanning/content sanitization requirements before persistence.
+   - Approved and implemented in PR `#66`, linked delivery issue `#64` closed.
 3. BC-08 SLA governance finalization (`#54`)
-   - final at-risk, breach, and compliance cutoffs.
+   - Approved and implemented in PR `#65`, linked delivery issue `#63` closed.
 
 ---
 

--- a/docs/Business-Confirmation-Checklist.md
+++ b/docs/Business-Confirmation-Checklist.md
@@ -40,7 +40,7 @@ Source:
 | BC-04 | Implemented | Closed `#50` | [#56](https://github.com/abdallahh166/TowerOps/pull/56) | Standardized structured error envelope across API responses |
 | BC-07 | Implemented | Closed `#53` | [#56](https://github.com/abdallahh166/TowerOps/pull/56) | Unified pagination/sort contract and sort-field allowlists |
 | BC-05 | Planned | Open `#62` | TBD | Decision approved. Pending implementation (retention, legal hold, export flow). Supersedes delivery tracking from `#58`. |
-| BC-06 | In Delivery | Open `#64` | TBD (`feat/bc-06-quarantine-upload`) | Quarantine-first upload pipeline, magic-byte validation, malware scan worker, and approved-only portal/report serving implemented on feature branch; pending PR merge. |
+| BC-06 | Implemented | Closed `#64` | [#66](https://github.com/abdallahh166/TowerOps/pull/66) | Implemented and merged: quarantine-first uploads, magic-byte + extension validation, malware scan worker, and approved-only portal/report file serving. |
 | BC-08 | Implemented | Closed `#63` | [#65](https://github.com/abdallahh166/TowerOps/pull/65) | Implemented and merged: CM/PM SLA start rules, type-based at-risk thresholds, UTC authority, engineer completion metadata, and migrations. |
 
 ## After Each Decision

--- a/docs/Documentation-Gap-Report.md
+++ b/docs/Documentation-Gap-Report.md
@@ -40,9 +40,9 @@ This report captures documentation areas that still need follow-up to keep docs 
 - Recommendation: Add runbooks under `docs/ops/`.
 
 ### 6) Business confirmations and implementation closure
-- Gap: BC-05 remains pending implementation (retention/privacy). BC-06 is in delivery branch and pending merge.
-- Impact: High (security and contract drift risk if frontend proceeds before backend closure).
-- Recommendation: Track approved policies as mandatory implementation scope in phase PR slices before frontend dependency freeze.
+- Gap: BC-05 remains pending implementation (retention/privacy/legal hold/export). BC-06 and BC-08 are implemented.
+- Impact: High for BC-05 (compliance and data governance), low for already implemented BC-06/08.
+- Recommendation: Keep BC-05 as the only high-priority remaining confirmation implementation slice before production freeze.
 - Tracking file: `docs/Business-Confirmation-Checklist.md`
 - Issue tracking:
   - BC-01: `#47`


### PR DESCRIPTION
## Summary
Post-merge documentation sync after BC-06 PR #66 landed.

## Changes
- Marked BC-06 as **Implemented** in `docs/Business-Confirmation-Checklist.md`.
- Updated `docs/Documentation-Gap-Report.md` to reflect:
  - BC-06 and BC-08 implemented
  - BC-05 is the remaining high-priority pending slice.
- Updated `docs/Backend-Auto-Discovery-Report.md` section 3.2 from "clarification required" to current implementation status.

## Why
PR #66 is merged and issue #64 is closed; tracker docs needed to be aligned with current project reality.
