### PR TITLE
docs(bc): finalize BC-05 status after implementation merge

### DIFF
--- a/docs/Business-Confirmation-Checklist.md
+++ b/docs/Business-Confirmation-Checklist.md
@@ -39,7 +39,7 @@ Source:
 | BC-03 | Implemented | Closed `#49` | [#56](https://github.com/abdallahh166/TowerOps/pull/56) | `portal.view_workorders` vs `portal.manage_workorders` split enforced |
 | BC-04 | Implemented | Closed `#50` | [#56](https://github.com/abdallahh166/TowerOps/pull/56) | Standardized structured error envelope across API responses |
 | BC-07 | Implemented | Closed `#53` | [#56](https://github.com/abdallahh166/TowerOps/pull/56) | Unified pagination/sort contract and sort-field allowlists |
-| BC-05 | In Delivery | Open `#62` | TBD | Implementation in progress: legal-hold flags + retention cleanup worker + self-service data export API/commands/migration/tests added on feature branch, pending PR merge. Supersedes delivery tracking from `#58`. |
+| BC-05 | Implemented | Closed `#62` | [#68](https://github.com/abdallahh166/TowerOps/pull/68) | Implemented and merged: legal-hold flags, retention cleanup worker, self-service authenticated data export API, migration, tests, and docs updates. Supersedes delivery tracking from `#58`. |
 | BC-06 | Implemented | Closed `#64` | [#66](https://github.com/abdallahh166/TowerOps/pull/66) | Implemented and merged: quarantine-first uploads, magic-byte + extension validation, malware scan worker, and approved-only portal/report file serving. |
 | BC-08 | Implemented | Closed `#63` | [#65](https://github.com/abdallahh166/TowerOps/pull/65) | Implemented and merged: CM/PM SLA start rules, type-based at-risk thresholds, UTC authority, engineer completion metadata, and migrations. |
 

--- a/docs/Documentation-Gap-Report.md
+++ b/docs/Documentation-Gap-Report.md
@@ -40,9 +40,9 @@ This report captures documentation areas that still need follow-up to keep docs 
 - Recommendation: Add runbooks under `docs/ops/`.
 
 ### 6) Business confirmations and implementation closure
-- Gap: BC-05 is in delivery (retention/privacy/legal hold/export code added, pending final PR merge and production rollout validation). BC-06 and BC-08 are implemented.
-- Impact: Medium (final validation/merge window) for BC-05, low for BC-06/08.
-- Recommendation: Complete BC-05 merge, run staging retention dry-run, and close remaining tracking issue.
+- Status: BC-05, BC-06, and BC-08 are implemented and merged.
+- Impact: Low (remaining work is operational rollout validation, not implementation closure).
+- Recommendation: Run staging retention dry-run verification and archive BC delivery tickets as complete.
 - Tracking file: `docs/Business-Confirmation-Checklist.md`
 - Issue tracking:
   - BC-01: `#47`

--- a/docs/phase-2/18-business-confirmation-implementation-pr-slices.md
+++ b/docs/phase-2/18-business-confirmation-implementation-pr-slices.md
@@ -8,7 +8,7 @@ Source decisions:
 
 ## Priority
 - P0: BC-01, BC-02, BC-03, BC-04, BC-07
-- P1: BC-05, BC-06, BC-08 (pending business closure)
+- P1: BC-05, BC-06, BC-08 (implemented; keep for traceability)
 
 ## PR-Slice Plan
 
@@ -101,7 +101,7 @@ Acceptance Criteria:
 
 ## BC-05 Data Retention and Privacy
 Issue: [#51](https://github.com/abdallahh166/TowerOps/issues/51)  
-Status: approved decision; implementation tracked in [#62](https://github.com/abdallahh166/TowerOps/issues/62) and currently in delivery.
+Status: implemented and merged in [#68](https://github.com/abdallahh166/TowerOps/pull/68). Delivery tracking issue [#62](https://github.com/abdallahh166/TowerOps/issues/62) is closed.
 
 ## BC-06 Upload Security Policy
 Issue: [#52](https://github.com/abdallahh166/TowerOps/issues/52)  


### PR DESCRIPTION
## Summary\n- mark BC-05 as Implemented in business confirmation tracker\n- update documentation gap report to reflect BC-05/06/08 implementation closure\n- update implementation PR slices document status for BC-05 (merged in #68)\n\n## Context\nPR #68 merged BC-05 implementation. This PR is a post-merge docs sync only.